### PR TITLE
Rewrite Quick Start guide

### DIFF
--- a/docs/en/about/quick-start.md
+++ b/docs/en/about/quick-start.md
@@ -3,57 +3,58 @@
 **Current Status:**
 Pre-release: Currently under development and not yet ready for official release.
 
-## First Steps
-To get Pumpkin running, you first have to clone it:
+## Rust
+
+To run Pumpkin with Rust, ensure you have [Rust]() installed.
+
+1. Clone the repository:
 ```shell
 git clone https://github.com/Pumpkin-MC/Pumpkin.git
 cd Pumpkin
 ```
-## Rust
-This is the intended way to install Pumpkin.
 
-You may also have to [install Rust](https://www.rust-lang.org/tools/install) if you don't already have it.
+2. **Optional:** If you wish, you can place a Vanilla world into the `Pumpkin/` directory. Just name the world folder `world`.
 
-**Optional:**
-
-If you wish, you can place a Vanilla world into the `Pumpkin/ directory`. Just name the world folder `world`.
-
-Then run:
+3. Run:
 
 > [!NOTE]
-> This can take a while because we enabled heavy optimizations for release builds.
->
-> To apply further optimizations specific to your CPU and use your CPU features, you should set the `target-cpu=native`
-> Rust compiler flag.
+> The build process may take a while, due to heavy optimizations for release builds.
 
 ```shell
 cargo run --release
 ```
-To set the Rust flag to `target-cpu=native`, use the following command to launch the server instead.
+
+4. **Optional:** If you want to use your CPU features, you can set the `target-cpu=native` Rust compiler flag.
 ```shell
 RUSTFLAGS='-C target-cpu=native' cargo run --release
 ```
 
 ## Docker
 
-Experimental Docker support is available.
+> [!IMPORTANT]
+> Docker support is currently experimental.
 
-You may also have to [install Docker](https://docs.docker.com/engine/install/).
-
-The Docker image is currently not published anywhere, but you can use the following command from the cloned directory named `Pumpkin` where you ran the [clone](#first-steps) command from to build and deploy it:
+If you haven't already, you need to [install Docker](https://docs.docker.com/engine/install/). After installing Docker, you can run the following command to start the server:
 
 ```shell
-docker build . -T pumpkin && docker run --rm -p <Exposed Port>:25565 -v <Server Data Location>:/pumpkin -it pumpkin
+docker run --rm \
+    -p <exposed_port>:25565  \
+    -v <server_data_location>:/pumpkin \
+    -it ghcr.io/pumpkin-mc/pumpkin:master
 ```
-- Replace `<Exposed Port>` with the port you want to connect with to Pumpkin, for example `25565`
-- Replace `<Server Data Location>` with the location where you want your server config to be stored, for example `./data`
-For example, with the `<Server Data Location>` set to `./data` and the `<Exposed Port>` set to `25565`, the command is as follows:
-```shell
-docker build . -t pumpkin && docker run --rm -p 25565:25565 -v ./data:/pumpkin -it pumpkin
-```
-After running this command a folder should appear in your chosen location in which you'll be able to find all the server files.
-Within this folder you can put your `world/` folder (make sure you restart the server).
 
+- `<exposed_port>`: The port you want to connect to Pumpkin with, for example `25565`.
+- `<server_data_location>`: The location where you want your server config and data to be stored, for example `./data`.
+
+### Example 
+
+To run Pumkin on port `25565` and store data in a directory called `./data`, you would run the following command:
+```shell
+docker run --rm \
+    -p 25565:25565 \
+    -v ./data:/pumpkin \
+    -it ghcr.io/pumpkin-mc/pumpkin:master
+```
 
 ## Test Server
 Pumpkin has a test server maintained by @kralverde. Its runs on the latest commit of Pumpkin's master branch.

--- a/docs/en/about/quick-start.md
+++ b/docs/en/about/quick-start.md
@@ -5,7 +5,7 @@ Pre-release: Currently under development and not yet ready for official release.
 
 ## Rust
 
-To run Pumpkin with Rust, ensure you have [Rust]() installed.
+To run Pumpkin with Rust, ensure you have [Rust](https://www.rust-lang.org/tools/install) installed.
 
 1. Clone the repository:
 ```shell

--- a/docs/en/about/quick-start.md
+++ b/docs/en/about/quick-start.md
@@ -48,7 +48,7 @@ docker run --rm \
 
 ### Example 
 
-To run Pumkin on port `25565` and store data in a directory called `./data`, you would run the following command:
+To run Pumpkin on port `25565` and store data in a directory called `./data`, you would run the following command:
 ```shell
 docker run --rm \
     -p 25565:25565 \


### PR DESCRIPTION
The current quick start guide was (in my personal opinion) a bit convoluted.
I also changed the docker commands to use the ghcr image instead of building from source.