### PR TITLE
Add Portuguese Localization

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -2,6 +2,6 @@
 extend-exclude = [
     "docs/nl/",
     "docs/.vitepress/nl.ts",
-    "docs/pt/,
-    "docs/.vitepress/pt.ts
+    "docs/pt/",
+    "docs/.vitepress/pt.ts"
 ]

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,7 @@
 [files]
 extend-exclude = [
     "docs/nl/",
-    "docs/.vitepress/nl.ts"
+    "docs/.vitepress/nl.ts",
+    "docs/pt/,
+    "docs/.vitepress/pt.ts
 ]

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vitepress";
 import { en } from "./en";
 import { nl } from "./nl";
+import { pt } from "./pt";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -17,6 +18,9 @@ export default defineConfig({
         },
         nl: {
             label: "Dutch", ...nl
+        },
+        pt: {
+            label: "Português", ...pt
         }
     },
 

--- a/docs/.vitepress/pt.ts
+++ b/docs/.vitepress/pt.ts
@@ -1,0 +1,123 @@
+import { defineConfig } from "vitepress";
+
+export const pt = defineConfig({
+    lang: "pt-BR",
+    description: "Um servidor Minecraft de alto desempenho escrito em Rust",
+
+    themeConfig: {
+        // https://vitepress.dev/reference/default-theme-config
+        search: {
+            provider: "local",
+        },
+        nav: [
+            {
+                text: "Documentação",
+                link: "/pt/about/introduction",
+            },
+        ],
+        sidebar: [
+            {
+                text: "Sobre",
+                items: [
+                    { text: "Introdução", link: "/pt/about/introduction" },
+                    { text: "Primeiros Passos", link: "/pt/about/quick-start" },
+                    { text: "Benchmark", link: "/pt/about/benchmarks" },
+                ],
+            },
+            {
+                text: "Configuração",
+                items: [
+                    { text: "Introdução", link: "/pt/config/introduction" },
+                    { text: "Básico", link: "/pt/config/basic" },
+                    { text: "Proxy", link: "/pt/config/proxy" },
+                    { text: "Autenticação", link: "/pt/config/authentication" },
+                    { text: "Compressão", link: "/pt/config/compression" },
+                    { text: "Pacote de Recursos", link: "/pt/config/resource-pack" },
+                    { text: "Comandos", link: "/pt/config/commands" },
+                    { text: "RCON", link: "/pt/config/rcon" },
+                    { text: "PVP", link: "/pt/config/pvp" },
+                    { text: "Log", link: "/pt/config/logging" },
+                    { text: "Query", link: "/pt/config/query" },
+                    { text: "Transmissão LAN", link: "/pt/config/lan-broadcast" },
+                ],
+            },
+            {
+                text: "Desenvolvedores",
+                items: [
+                    { text: "Contribuindo", link: "/pt/developer/contributing" },
+                    { text: "Introdução", link: "/pt/developer/introduction" },
+                    {
+                        text: "Rede",
+                        link: "/pt/developer/networking/networking",
+                        items: [
+                            { text: "Autenticação", link: "/pt/developer/networking/authentication" },
+                            { text: "RCON", link: "/pt/developer/networking/rcon" },
+                        ]
+                    },
+                    { text: "Mundo", link: "/pt/developer/world" },
+                    { text: "Desenvolvimento Mobile", link: "/pt/developer/mobile" },
+                ],
+            },
+            {
+                text: "Desenvolvimento de Plugins",
+                items: [
+                    {
+                        text: "Introdução",
+                        link: "/pt/plugin-dev/introduction",
+                    },
+                    {
+                        text: "Exemplos de Plugin",
+                        link: "/pt/plugin-dev/plugin-template/introduction",
+                        items: [
+                            {
+                                text: "Criando um projeto",
+                                link: "/pt/plugin-dev/plugin-template/creating-project",
+                            },
+                            {
+                                text: "Lógica básica",
+                                link: "/pt/plugin-dev/plugin-template/basic-logic",
+                            },
+                            {
+                                text: "Gerenciador de eventos",
+                                link: "/pt/plugin-dev/plugin-template/join-event",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                text: "Solução de Problemas",
+                items: [
+                    {
+                        text: "Problemas Comuns",
+                        link: "/pt/troubleshooting/common_issues.md",
+                    },
+                ],
+            },
+        ],
+
+        socialLinks: [
+            { icon: "github", link: "https://github.com/Pumpkin-MC/Pumpkin" },
+            { icon: "discord", link: "https://discord.gg/RNm224ZsDq" },
+        ],
+
+        logo: "/assets/favicon.ico",
+        footer: {
+            message: "Distribuído sob a Licença MIT.",
+            copyright: `Copyright © 2024-${new Date().getFullYear()} Aleksandr Medvedev`,
+        },
+        editLink: {
+            pattern:
+                "https://github.com/Pumpkin-MC/Pumpkin-Website/blob/master/docs/:path",
+            text: "Edite esta página no GitHub",
+        },
+        lastUpdated: {
+            text: "Atualizado em",
+            formatOptions: {
+                dateStyle: "medium",
+                timeStyle: "medium",
+            },
+        },
+        outline: "deep",
+    }
+});

--- a/docs/pt/about/benchmarks.md
+++ b/docs/pt/about/benchmarks.md
@@ -1,188 +1,187 @@
 # Benchmarks
 
-Here, common Minecraft server software is compared against Pumpkin.
+Aqui, softwares de servidores Minecraft comuns são comparados com o Pumpkin.
 
-> [!CAUTION]
-> **This comparison is unfair.** Pumpkin currently has far fewer features than other servers, which might suggest it uses fewer resources.
-> It's also important to consider that other servers have had years to optimize.
-> Vanilla forks, which don’t need to rewrite the entire Vanilla logic, can focus exclusively on optimizations.
+> [!CAUTION] CUIDADO
+> **Esta comparação é injusta.** Pumpkin atualmente tem muito menos recursos que outros servidores, o que pode sugerir que ele usa menos recursos.
+> Também é importante considerar que outros servidores tiveram anos para otimizar.
+> Forks do Vanilla, que não precisam reescrever toda a lógica do Vanilla, podem se concentrar exclusivamente em otimizações.
 
 ![Screenshot From 2024-10-15 16-42-53](https://github.com/user-attachments/assets/e08fbb00-42fe-4479-a03b-11bb6886c91a)
 
-## Specifications
+## Especificações
 
-#### Technical
+#### Técnicas
 
 **Software**
 
-- Distribution: Manjaro Linux
-- Architecture: x86_64 (64-bit)
-- Kernel Version: 6.11.3-arch1-1
+-   Distribuição: Manjaro Linux
+-   Arquitetura: x86_64 (64-bit)
+-   Versão do Kernel: 6.11.3-arch1-1
 
 **Hardware**
 
-- Motherboard: MAG B650 TOMAHAWK WIFI
-- CPU: AMD Ryzen 7600X 6-Core
-- RAM: Corsair 2x16GB DDR5 6000Mhz
-- Storage: Samsung 990 PRO 1TB PCIe 4.0 M.2 SSD
-- Cooling: be quiet Dark Rock Elite
+-   Placa-mãe: MAG B650 TOMAHAWK WIFI
+-   CPU: AMD Ryzen 7600X 6-Core
+-   RAM: Corsair 2x16GB DDR5 6000Mhz
+-   Armazenamento: Samsung 990 PRO 1TB PCIe 4.0 M.2 SSD
+-   Refrigeração: be quiet Dark Rock Elite
 
 **Rust**
 
-- Toolchain: stable-x86_64-unknown-linux-gnu (1.81.0)
-- Rust Compiler: rustc 1.81.0 (eeb90cda1 2024-09-04)
+-   Toolchain: stable-x86_64-unknown-linux-gnu (1.81.0)
+-   Compilador Rust: rustc 1.81.0 (eeb90cda1 2024-09-04)
 
 **Java**
 
-- JDK Version: OpenJDK 23 64-Bit 2024-09-17
-- JRE Version: OpenJDK Runtime Environment (build 23+37)
-- Vendor: Oracle
+-   Versão do JDK: OpenJDK 23 64-Bit 2024-09-17
+-   Versão do JRE: OpenJDK Runtime Environment (build 23+37)
+-   Fornecedor: Oracle
 
-#### Game
+#### Jogo
 
-- Minecraft version: 1.21.1
-- View distance: 10
-- Simulated distance: 10
-- Online mode: false
-- Rcon: false
+-   Versão do Minecraft: 1.21.1
+-   Distância de visão: 10
+-   Distância simulada: 10
+-   Modo online: falso
+-   Rcon: falso
 
-<sub><sup>Online mode was disabled for easier testing with non-premium accounts.</sup></sub>
+<sub><sup>O modo online foi desativado para facilitar os testes com contas não premium.</sup></sub>
 
-> [!NOTE]
-> All tests have been ran multiple times for more accurate results.
-> All players did not move when spawning. Only the initial 8 chunks were loaded.
-> All servers used their own terrain generation. No world was pre-loaded.
+> [!NOTE] NOTA
+> Todos os testes foram realizados várias vezes para obter resultados mais precisos.
+> Todos os jogadores não se moveram ao nascer. Apenas os 8 primeiros chunks foram carregados.
+> Todos os servidores usaram sua própria geração de terreno. Nenhum mundo foi pré-carregado.
 
-> [!IMPORTANT]
-> `CPU Max` is usually higher with one player because the initial chunks are being loaded.
+> [!IMPORTANT] IMPORTANTE
+> `CPU Max` geralmente é maior com um jogador, pois os chunks iniciais estão sendo carregados.
 
 ## Pumpkin
 
 Build: [8febc50](https://github.com/Snowiiii/Pumpkin/commit/8febc5035d5611558c13505b7724e6ca284e0ada)
 
-Compile args: `--release`
+Argumentos de compilação: `--release`
 
-Run args:
+Argumentos de execução:
 
-**File Size:** <FmtNum :n=12.3 />MB
+**Tamanho do arquivo:** <FmtNum :n=12.3 />MB
 
-**Startup time:** <FmtNum :n=8 />ms
+**Tempo de inicialização:** <FmtNum :n=8 />ms
 
-**Shutdown time:** <FmtNum :n=0 />ms
+**Tempo de desligamento:** <FmtNum :n=0 />ms
 
-| Players | RAM                   | CPU Idle         | CPU Max            |
-| ------- | --------------------- | ---------------- | ------------------ |
-| 0       | <FmtNum :n=392.2 />KB | <FmtNum :n=0 />% | <FmtNum :n=0 />%   |
-| 1       | <FmtNum :n=24.9 />MB  | <FmtNum :n=0 />% | <FmtNum :n=4 />%   |
-| 2       | <FmtNum :n=25.1 />MB  | <FmtNum :n=0 />% | <FmtNum :n=0.6 />% |
-| 5       | <FmtNum :n=26 />MB    | <FmtNum :n=0 />% | <FmtNum :n=1 />%   |
-| 10      | <FmtNum :n=27.1 />MB  | <FmtNum :n=0 />% | <FmtNum :n=1.5 />% |
+| Jogadores | RAM                   | CPU Ocioso       | CPU Máx            |
+| --------- | --------------------- | ---------------- | ------------------ |
+| 0         | <FmtNum :n=392.2 />KB | <FmtNum :n=0 />% | <FmtNum :n=0 />%   |
+| 1         | <FmtNum :n=24.9 />MB  | <FmtNum :n=0 />% | <FmtNum :n=4 />%   |
+| 2         | <FmtNum :n=25.1 />MB  | <FmtNum :n=0 />% | <FmtNum :n=0.6 />% |
+| 5         | <FmtNum :n=26 />MB    | <FmtNum :n=0 />% | <FmtNum :n=1 />%   |
+| 10        | <FmtNum :n=27.1 />MB  | <FmtNum :n=0 />% | <FmtNum :n=1.5 />% |
 
-<sub><sup>Pumpkin does cache already loaded chunks, resulting in no extra RAM usage besides player data and minimal CPU usage.</sup></sub>
+<sub><sup>Pumpkin faz cache dos chunks já carregados, resultando em nenhum uso extra de RAM além dos dados do jogador e uso mínimo de CPU.</sup></sub>
 
-#### Compile time
-Compiling from nothing:
+#### Tempo de compilação
 
-**Debug:** <FmtNum :n=10.35 />sec
+Compilando do zero:
+
+**Debug:** <FmtNum :n=10.35 />sec  
 **Release:** <FmtNum :n=38.40 />sec
 
-Recompilation (pumpkin crate):
+Recompilação (pumpkin crate):
 
-**Debug:** <FmtNum :n=1.82 />sec
+**Debug:** <FmtNum :n=1.82 />sec  
 **Release:** <FmtNum :n=28.68 />sec
 
 ## Vanilla
 
 Release: [1.21.1](https://piston-data.mojang.com/v1/objects/59353fb40c36d304f2035d51e7d6e6baa98dc05c/server.jar)
 
-Compile args:
+Argumentos de compilação:
 
-Run args: `nogui`
+Argumentos de execução: `nogui`
 
-**File Size:** <FmtNum :n=51.6 />MB
+**Tamanho do arquivo:** <FmtNum :n=51.6 />MB
 
-**Startup time:** <FmtNum :n=7 />sec
+**Tempo de inicialização:** <FmtNum :n=7 />sec
 
-**Shutdown time:** <FmtNum :n=4 />sec
+**Tempo de desligamento:** <FmtNum :n=4 />sec
 
-| Players | RAM                   | CPU idle                                 | CPU Max            |
-| ------- | --------------------- | ---------------------------------------- | ------------------ |
-| 0       | <FmtNum n="860" />MB  | <FmtNum n="0.1" /> - <FmtNum n="0.3" />% | <FmtNum n="51" />% |
-| 1       | <FmtNum n="1.5" />GB  | <FmtNum n="0.9" /> - <FmtNum n="1" />%   | <FmtNum n="41" />% |
-| 2       | <FmtNum n="1.6" />GB  | <FmtNum n="1" /> - <FmtNum n="1.1" />%   | <FmtNum n="10" />% |
-| 5       | <FmtNum n="1.8" />GB  | <FmtNum n="2" />%                        | <FmtNum n="20" />% |
-| 10      | <FmtNum n="2.2" />GB  | <FmtNum n="4" />%                        | <FmtNum n="24" />% |
+| Jogadores | RAM                  | CPU ocioso                               | CPU Máx            |
+| --------- | -------------------- | ---------------------------------------- | ------------------ |
+| 0         | <FmtNum n="860" />MB | <FmtNum n="0.1" /> - <FmtNum n="0.3" />% | <FmtNum n="51" />% |
+| 1         | <FmtNum n="1.5" />GB | <FmtNum n="0.9" /> - <FmtNum n="1" />%   | <FmtNum n="41" />% |
+| 2         | <FmtNum n="1.6" />GB | <FmtNum n="1" /> - <FmtNum n="1.1" />%   | <FmtNum n="10" />% |
+| 5         | <FmtNum n="1.8" />GB | <FmtNum n="2" />%                        | <FmtNum n="20" />% |
+| 10        | <FmtNum n="2.2" />GB | <FmtNum n="4" />%                        | <FmtNum n="24" />% |
 
 ## Paper
 
 Build: [122](https://api.papermc.io/v2/projects/paper/versions/1.21.1/builds/122/downloads/paper-1.21.1-122.jar)
 
-Compile args:
+Argumentos de compilação:
 
-Run args: `nogui`
+Argumentos de execução: `nogui`
 
-**File Size:** <FmtNum :n=49.4 />MB
+**Tamanho do arquivo:** <FmtNum :n=49.4 />MB
 
-**Startup time:** <FmtNum :n=7 />sec
+**Tempo de inicialização:** <FmtNum :n=7 />sec
 
-**Shutdown time:** <FmtNum :n=3 />sec
+**Tempo de desligamento:** <FmtNum :n=3 />sec
 
-| Players | RAM                 | CPU idle                               | CPU Max           |
-| ------- | ------------------- | -------------------------------------- | ----------------- |
-| 0       | <FmtNum :n=1.1 />GB | <FmtNum :n=0.2 /> - <FmtNum :n=0.3 />% | <FmtNum :n=36 />% |
-| 1       | <FmtNum :n=1.7 />GB | <FmtNum :n=0.9 /> - <FmtNum :n=1.0 />% | <FmtNum :n=47 />% |
-| 2       | <FmtNum :n=1.8 />GB | <FmtNum :n=1 /> - <FmtNum :n=1.1 />%   | <FmtNum :n=10 />% |
-| 5       | <FmtNum :n=1.9 />GB | <FmtNum :n=1.5 />%                     | <FmtNum :n=15 />% |
-| 10      | <FmtNum :n=2 />GB   | <FmtNum :n=3 />%                       | <FmtNum :n=20 />% |
-
+| Jogadores | RAM                 | CPU ocioso                             | CPU Máx           |
+| --------- | ------------------- | -------------------------------------- | ----------------- |
+| 0         | <FmtNum :n=1.1 />GB | <FmtNum :n=0.2 /> - <FmtNum :n=0.3 />% | <FmtNum :n=36 />% |
+| 1         | <FmtNum :n=1.7 />GB | <FmtNum :n=0.9 /> - <FmtNum :n=1.0 />% | <FmtNum :n=47 />% |
+| 2         | <FmtNum :n=1.8 />GB | <FmtNum :n=1 /> - <FmtNum :n=1.1 />%   | <FmtNum :n=10 />% |
+| 5         | <FmtNum :n=1.9 />GB | <FmtNum :n=1.5 />%                     | <FmtNum :n=15 />% |
+| 10        | <FmtNum :n=2 />GB   | <FmtNum :n=3 />%                       | <FmtNum :n=20 />% |
 
 ## Purpur
 
 Build: [2324](https://api.purpurmc.org/v2/purpur/1.21.1/2324/download)
 
-Compile args:
+Argumentos de compilação:
 
-Run args: `nogui`
+Argumentos de execução: `nogui`
 
-**File Size:** <FmtNum :n=53.1 />MB
+**Tamanho do arquivo:** <FmtNum :n=53.1 />MB
 
-**Startup time:** <FmtNum :n=8 />sec
+**Tempo de inicialização:** <FmtNum :n=8 />sec
 
-**Shutdown time:** <FmtNum :n=4 />sec
+**Tempo de desligamento:** <FmtNum :n=4 />sec
 
-| Players | RAM                 | CPU idle                               | CPU Max           |
-| ------- | ------------------- | -------------------------------------- | ----------------- |
-| 0       | <FmtNum :n=1.4 />GB | <FmtNum :n=0.2 /> - <FmtNum :n=0.3 />% | <FmtNum :n=25 />% |
-| 1       | <FmtNum :n=1.6 />GB | <FmtNum :n=0.7 /> - <FmtNum :n=1.0 />% | <FmtNum :n=35 />% |
-| 2       | <FmtNum :n=1.7 />GB | <FmtNum :n=1.1 /> - <FmtNum :n=1.3 />% | <FmtNum :n=9 />%  |
-| 5       | <FmtNum :n=1.9 />GB | <FmtNum :n=1.6 />%                     | <FmtNum :n=20 />% |
-| 10      | <FmtNum :n=2.2 />GB | <FmtNum :n=2 /> - <FmtNum :n=2.5 />%   | <FmtNum :n=26 />% |
+| Jogadores | RAM                 | CPU ocioso                             | CPU Máx           |
+| --------- | ------------------- | -------------------------------------- | ----------------- |
+| 0         | <FmtNum :n=1.4 />GB | <FmtNum :n=0.2 /> - <FmtNum :n=0.3 />% | <FmtNum :n=25 />% |
+| 1         | <FmtNum :n=1.6 />GB | <FmtNum :n=0.7 /> - <FmtNum :n=1.0 />% | <FmtNum :n=35 />% |
+| 2         | <FmtNum :n=1.7 />GB | <FmtNum :n=1.1 /> - <FmtNum :n=1.3 />% | <FmtNum :n=9 />%  |
+| 5         | <FmtNum :n=1.9 />GB | <FmtNum :n=1.6 />%                     | <FmtNum :n=20 />% |
+| 10        | <FmtNum :n=2.2 />GB | <FmtNum :n=2 /> - <FmtNum :n=2.5 />%   | <FmtNum :n=26 />% |
 
 ## Minestom
 
 Commit: [0ca1dda2fe](https://github.com/Minestom/Minestom/commit/0ca1dda2fe11390a1b89a228bbe7bf78fefc73e1)
 
-Compile args:
+Argumentos de compilação:
 
-Run args:
+Argumentos de execução:
 
-**Language:** Benchmarks ran with Kotlin 2.0.0 (Minestom itself is made with Java)
+**Idioma:** Benchmarks executados com Kotlin 2.0.0 (Minestom é feito com Java)
 
-**File Size:** <FmtNum :n=2.8 />MB (Library)
+**Tamanho do arquivo:** <FmtNum :n=2.8 />MB (Biblioteca)
 
-**Startup time:** <FmtNum :n=310 />ms
+**Tempo de inicialização:** <FmtNum :n=310 />ms
 
-**Shutdown time:** <FmtNum :n=0 />ms
+**Tempo de desligamento:** <FmtNum :n=0 />ms
 
-<sub>[Used example code from](https://minestom.net/docs/setup/your-first-server)</sub>
+<sub>[Usado o código do exemplo de](https://minestom.net/docs/setup/your-first-server)</sub>
 
-| Players | RAM                 | CPU idle                               | CPU Max          |
-| ------- | ------------------- | -------------------------------------- | ---------------- |
-| 0       | <FmtNum :n=228 />MB | <FmtNum :n=0.1 /> - <FmtNum :n=0.3 />% | <FmtNum :n=1 />% |
-| 1       | <FmtNum :n=365 />MB | <FmtNum :n=0.9 /> - <FmtNum :n=1.0 />% | <FmtNum :n=5 />% |
-| 2       | <FmtNum :n=371 />MB | <FmtNum :n=1 /> - <FmtNum :n=1.1 />%   | <FmtNum :n=4 />% |
-| 5       | <FmtNum :n=390 />MB | <FmtNum :n=1.0 />%                     | <FmtNum :n=6 />% |
-| 10      | <FmtNum :n=421 />MB | <FmtNum :n=3 />%                       | <FmtNum :n=9 />% |
+| Jogadores | RAM                 | CPU ocioso                             | CPU Máx          |
+| --------- | ------------------- | -------------------------------------- | ---------------- |
+| 0         | <FmtNum :n=228 />MB | <FmtNum :n=0.1 /> - <FmtNum :n=0.3 />% | <FmtNum :n=1 />% |
+| 1         | <FmtNum :n=365 />MB | <FmtNum :n=0.9 /> - <FmtNum :n=1.0 />% | <FmtNum :n=5 />% |
+| 2         | <FmtNum :n=371 />MB | <FmtNum :n=1 /> - <FmtNum :n=1.1 />%   | <FmtNum :n=4 />% |
+| 5         | <FmtNum :n=390 />MB | <FmtNum :n=1.0 />%                     | <FmtNum :n=6 />% |
+| 10        | <FmtNum :n=421 />MB | <FmtNum :n=3 />%                       | <FmtNum :n=9 />% |
 
-
-Benchmarked at <FmtDateTime :d="new Date('2024-10-15T16:34Z')" />
+Benchmarks realizados em <FmtDateTime :d="new Date('2024-10-15T16:34Z')" />

--- a/docs/pt/about/benchmarks.md
+++ b/docs/pt/about/benchmarks.md
@@ -1,0 +1,188 @@
+# Benchmarks
+
+Here, common Minecraft server software is compared against Pumpkin.
+
+> [!CAUTION]
+> **This comparison is unfair.** Pumpkin currently has far fewer features than other servers, which might suggest it uses fewer resources.
+> It's also important to consider that other servers have had years to optimize.
+> Vanilla forks, which don’t need to rewrite the entire Vanilla logic, can focus exclusively on optimizations.
+
+![Screenshot From 2024-10-15 16-42-53](https://github.com/user-attachments/assets/e08fbb00-42fe-4479-a03b-11bb6886c91a)
+
+## Specifications
+
+#### Technical
+
+**Software**
+
+- Distribution: Manjaro Linux
+- Architecture: x86_64 (64-bit)
+- Kernel Version: 6.11.3-arch1-1
+
+**Hardware**
+
+- Motherboard: MAG B650 TOMAHAWK WIFI
+- CPU: AMD Ryzen 7600X 6-Core
+- RAM: Corsair 2x16GB DDR5 6000Mhz
+- Storage: Samsung 990 PRO 1TB PCIe 4.0 M.2 SSD
+- Cooling: be quiet Dark Rock Elite
+
+**Rust**
+
+- Toolchain: stable-x86_64-unknown-linux-gnu (1.81.0)
+- Rust Compiler: rustc 1.81.0 (eeb90cda1 2024-09-04)
+
+**Java**
+
+- JDK Version: OpenJDK 23 64-Bit 2024-09-17
+- JRE Version: OpenJDK Runtime Environment (build 23+37)
+- Vendor: Oracle
+
+#### Game
+
+- Minecraft version: 1.21.1
+- View distance: 10
+- Simulated distance: 10
+- Online mode: false
+- Rcon: false
+
+<sub><sup>Online mode was disabled for easier testing with non-premium accounts.</sup></sub>
+
+> [!NOTE]
+> All tests have been ran multiple times for more accurate results.
+> All players did not move when spawning. Only the initial 8 chunks were loaded.
+> All servers used their own terrain generation. No world was pre-loaded.
+
+> [!IMPORTANT]
+> `CPU Max` is usually higher with one player because the initial chunks are being loaded.
+
+## Pumpkin
+
+Build: [8febc50](https://github.com/Snowiiii/Pumpkin/commit/8febc5035d5611558c13505b7724e6ca284e0ada)
+
+Compile args: `--release`
+
+Run args:
+
+**File Size:** <FmtNum :n=12.3 />MB
+
+**Startup time:** <FmtNum :n=8 />ms
+
+**Shutdown time:** <FmtNum :n=0 />ms
+
+| Players | RAM                   | CPU Idle         | CPU Max            |
+| ------- | --------------------- | ---------------- | ------------------ |
+| 0       | <FmtNum :n=392.2 />KB | <FmtNum :n=0 />% | <FmtNum :n=0 />%   |
+| 1       | <FmtNum :n=24.9 />MB  | <FmtNum :n=0 />% | <FmtNum :n=4 />%   |
+| 2       | <FmtNum :n=25.1 />MB  | <FmtNum :n=0 />% | <FmtNum :n=0.6 />% |
+| 5       | <FmtNum :n=26 />MB    | <FmtNum :n=0 />% | <FmtNum :n=1 />%   |
+| 10      | <FmtNum :n=27.1 />MB  | <FmtNum :n=0 />% | <FmtNum :n=1.5 />% |
+
+<sub><sup>Pumpkin does cache already loaded chunks, resulting in no extra RAM usage besides player data and minimal CPU usage.</sup></sub>
+
+#### Compile time
+Compiling from nothing:
+
+**Debug:** <FmtNum :n=10.35 />sec
+**Release:** <FmtNum :n=38.40 />sec
+
+Recompilation (pumpkin crate):
+
+**Debug:** <FmtNum :n=1.82 />sec
+**Release:** <FmtNum :n=28.68 />sec
+
+## Vanilla
+
+Release: [1.21.1](https://piston-data.mojang.com/v1/objects/59353fb40c36d304f2035d51e7d6e6baa98dc05c/server.jar)
+
+Compile args:
+
+Run args: `nogui`
+
+**File Size:** <FmtNum :n=51.6 />MB
+
+**Startup time:** <FmtNum :n=7 />sec
+
+**Shutdown time:** <FmtNum :n=4 />sec
+
+| Players | RAM                   | CPU idle                                 | CPU Max            |
+| ------- | --------------------- | ---------------------------------------- | ------------------ |
+| 0       | <FmtNum n="860" />MB  | <FmtNum n="0.1" /> - <FmtNum n="0.3" />% | <FmtNum n="51" />% |
+| 1       | <FmtNum n="1.5" />GB  | <FmtNum n="0.9" /> - <FmtNum n="1" />%   | <FmtNum n="41" />% |
+| 2       | <FmtNum n="1.6" />GB  | <FmtNum n="1" /> - <FmtNum n="1.1" />%   | <FmtNum n="10" />% |
+| 5       | <FmtNum n="1.8" />GB  | <FmtNum n="2" />%                        | <FmtNum n="20" />% |
+| 10      | <FmtNum n="2.2" />GB  | <FmtNum n="4" />%                        | <FmtNum n="24" />% |
+
+## Paper
+
+Build: [122](https://api.papermc.io/v2/projects/paper/versions/1.21.1/builds/122/downloads/paper-1.21.1-122.jar)
+
+Compile args:
+
+Run args: `nogui`
+
+**File Size:** <FmtNum :n=49.4 />MB
+
+**Startup time:** <FmtNum :n=7 />sec
+
+**Shutdown time:** <FmtNum :n=3 />sec
+
+| Players | RAM                 | CPU idle                               | CPU Max           |
+| ------- | ------------------- | -------------------------------------- | ----------------- |
+| 0       | <FmtNum :n=1.1 />GB | <FmtNum :n=0.2 /> - <FmtNum :n=0.3 />% | <FmtNum :n=36 />% |
+| 1       | <FmtNum :n=1.7 />GB | <FmtNum :n=0.9 /> - <FmtNum :n=1.0 />% | <FmtNum :n=47 />% |
+| 2       | <FmtNum :n=1.8 />GB | <FmtNum :n=1 /> - <FmtNum :n=1.1 />%   | <FmtNum :n=10 />% |
+| 5       | <FmtNum :n=1.9 />GB | <FmtNum :n=1.5 />%                     | <FmtNum :n=15 />% |
+| 10      | <FmtNum :n=2 />GB   | <FmtNum :n=3 />%                       | <FmtNum :n=20 />% |
+
+
+## Purpur
+
+Build: [2324](https://api.purpurmc.org/v2/purpur/1.21.1/2324/download)
+
+Compile args:
+
+Run args: `nogui`
+
+**File Size:** <FmtNum :n=53.1 />MB
+
+**Startup time:** <FmtNum :n=8 />sec
+
+**Shutdown time:** <FmtNum :n=4 />sec
+
+| Players | RAM                 | CPU idle                               | CPU Max           |
+| ------- | ------------------- | -------------------------------------- | ----------------- |
+| 0       | <FmtNum :n=1.4 />GB | <FmtNum :n=0.2 /> - <FmtNum :n=0.3 />% | <FmtNum :n=25 />% |
+| 1       | <FmtNum :n=1.6 />GB | <FmtNum :n=0.7 /> - <FmtNum :n=1.0 />% | <FmtNum :n=35 />% |
+| 2       | <FmtNum :n=1.7 />GB | <FmtNum :n=1.1 /> - <FmtNum :n=1.3 />% | <FmtNum :n=9 />%  |
+| 5       | <FmtNum :n=1.9 />GB | <FmtNum :n=1.6 />%                     | <FmtNum :n=20 />% |
+| 10      | <FmtNum :n=2.2 />GB | <FmtNum :n=2 /> - <FmtNum :n=2.5 />%   | <FmtNum :n=26 />% |
+
+## Minestom
+
+Commit: [0ca1dda2fe](https://github.com/Minestom/Minestom/commit/0ca1dda2fe11390a1b89a228bbe7bf78fefc73e1)
+
+Compile args:
+
+Run args:
+
+**Language:** Benchmarks ran with Kotlin 2.0.0 (Minestom itself is made with Java)
+
+**File Size:** <FmtNum :n=2.8 />MB (Library)
+
+**Startup time:** <FmtNum :n=310 />ms
+
+**Shutdown time:** <FmtNum :n=0 />ms
+
+<sub>[Used example code from](https://minestom.net/docs/setup/your-first-server)</sub>
+
+| Players | RAM                 | CPU idle                               | CPU Max          |
+| ------- | ------------------- | -------------------------------------- | ---------------- |
+| 0       | <FmtNum :n=228 />MB | <FmtNum :n=0.1 /> - <FmtNum :n=0.3 />% | <FmtNum :n=1 />% |
+| 1       | <FmtNum :n=365 />MB | <FmtNum :n=0.9 /> - <FmtNum :n=1.0 />% | <FmtNum :n=5 />% |
+| 2       | <FmtNum :n=371 />MB | <FmtNum :n=1 /> - <FmtNum :n=1.1 />%   | <FmtNum :n=4 />% |
+| 5       | <FmtNum :n=390 />MB | <FmtNum :n=1.0 />%                     | <FmtNum :n=6 />% |
+| 10      | <FmtNum :n=421 />MB | <FmtNum :n=3 />%                       | <FmtNum :n=9 />% |
+
+
+Benchmarked at <FmtDateTime :d="new Date('2024-10-15T16:34Z')" />

--- a/docs/pt/about/introduction.md
+++ b/docs/pt/about/introduction.md
@@ -1,0 +1,36 @@
+# Pumpkin
+
+Pumpkin is a Minecraft server built entirely in **Rust**, offering a fast, efficient,
+and customizable experience. It prioritizes performance and player enjoyment while adhering to the core mechanics of the game.
+
+<picture>
+  <source srcset="/assets/introduction-preview-2560x1440.png" media="(min-width: 2560px)">
+  <source srcset="/assets/introduction-preview-1280x720.png" media="(min-width: 1280px)">
+  <source srcset="/assets/introduction-preview-640x360.png" media="(min-width: 640px)">
+  <img src="/assets/introduction-preview-1280x720.png" alt="introduction-preview">
+</picture>
+
+## What Pumpkin wants to achieve
+
+- **Performance**: Leveraging multi-threading for maximum speed and efficiency.
+- **Compatibility**: Supports the latest Minecraft server version and adheres to Vanilla game mechanics.
+- **Security**: Prioritizes security by preventing known security exploits.
+- **Flexibility**: Highly configurable, with the ability to disable unnecessary features.
+- **Extensibility**: Provides a foundation for plugin development.
+
+## What Pumpkin will not
+
+- Be compatible with plugins or mods for other servers
+
+> [!IMPORTANT]
+> Pumpkin is currently under heavy development. Check out our [Github Project](https://github.com/orgs/Pumpkin-MC/projects/3) to see current progress.
+
+## Vanilla
+
+Pumpkin is designed to replicate Vanilla Minecraft logic as closely as possible,
+ensuring a familiar gameplay experience. However, we've also added new features to enhance gameplay.
+
+### Redstone
+
+Unlike other forks that may compromise redstone mechanics, Pumpkin maintains the Vanilla redstone behavior.
+If you're looking to experiment with redstone modifications or seek performance optimizations, you have the flexibility to do so through our configurable settings.

--- a/docs/pt/about/introduction.md
+++ b/docs/pt/about/introduction.md
@@ -1,7 +1,6 @@
 # Pumpkin
 
-Pumpkin is a Minecraft server built entirely in **Rust**, offering a fast, efficient,
-and customizable experience. It prioritizes performance and player enjoyment while adhering to the core mechanics of the game.
+Pumpkin é um servidor de Minecraft construído inteiramente em **Rust**, oferecendo uma experiência rápida, eficiente e personalizável. Ele prioriza o desempenho e experiência dos jogadores, enquanto adere às mecânicas fundamentais do jogo.
 
 <picture>
   <source srcset="/assets/introduction-preview-2560x1440.png" media="(min-width: 2560px)">
@@ -10,27 +9,25 @@ and customizable experience. It prioritizes performance and player enjoyment whi
   <img src="/assets/introduction-preview-1280x720.png" alt="introduction-preview">
 </picture>
 
-## What Pumpkin wants to achieve
+## O que o Pumpkin quer alcançar
 
-- **Performance**: Leveraging multi-threading for maximum speed and efficiency.
-- **Compatibility**: Supports the latest Minecraft server version and adheres to Vanilla game mechanics.
-- **Security**: Prioritizes security by preventing known security exploits.
-- **Flexibility**: Highly configurable, with the ability to disable unnecessary features.
-- **Extensibility**: Provides a foundation for plugin development.
+-   **Performance**: Aproveita o multi-threading para máxima velocidade e eficiência.
+-   **Compatibilidade**: Suporta a versão mais recente do servidor Minecraft e adere às mecânicas do jogo Vanilla.
+-   **Segurança**: Prioriza a segurança, prevenindo exploits de segurança conhecidos.
+-   **Flexibilidade**: Altamente configurável, com a capacidade de desativar funcionalidades desnecessárias.
+-   **Extensibilidade**: Oferece uma base para o desenvolvimento de plugins.
 
-## What Pumpkin will not
+## O que o Pumpkin não fará
 
-- Be compatible with plugins or mods for other servers
+-   Ser compatível com plugins ou mods de outros servidores.
 
-> [!IMPORTANT]
-> Pumpkin is currently under heavy development. Check out our [Github Project](https://github.com/orgs/Pumpkin-MC/projects/3) to see current progress.
+> [!IMPORTANT] IMPORTANTE
+> O Pumpkin está atualmente em desenvolvimento acelerado. Confira nosso [Projeto no Github](https://github.com/orgs/Pumpkin-MC/projects/3) para ver o progresso atual.
 
 ## Vanilla
 
-Pumpkin is designed to replicate Vanilla Minecraft logic as closely as possible,
-ensuring a familiar gameplay experience. However, we've also added new features to enhance gameplay.
+O Pumpkin foi projetado para replicar a lógica do Minecraft Vanilla o mais fielmente possível, garantindo uma experiência de jogo familiar. No entanto, também adicionamos novos recursos para aprimorar o gameplay.
 
 ### Redstone
 
-Unlike other forks that may compromise redstone mechanics, Pumpkin maintains the Vanilla redstone behavior.
-If you're looking to experiment with redstone modifications or seek performance optimizations, you have the flexibility to do so through our configurable settings.
+Ao contrário de outros forks que podem comprometer as mecânicas de redstone, o Pumpkin mantém o comportamento de redstone do Vanilla. Se você deseja experimentar modificações em redstone ou busca otimizações de desempenho, você tem flexibilidade para fazer isso por meio das nossas configurações ajustáveis.

--- a/docs/pt/about/quick-start.md
+++ b/docs/pt/about/quick-start.md
@@ -1,0 +1,68 @@
+# Quick Start
+
+**Current Status:**
+Pre-release: Currently under development and not yet ready for official release.
+
+## Rust
+
+To run Pumpkin with Rust, ensure you have [Rust](https://www.rust-lang.org/tools/install) installed.
+
+1. Clone the repository:
+```shell
+git clone https://github.com/Pumpkin-MC/Pumpkin.git
+cd Pumpkin
+```
+
+2. **Optional:** If you wish, you can place a Vanilla world into the `Pumpkin/` directory. Just name the world folder `world`.
+
+3. Run:
+
+> [!NOTE]
+> The build process may take a while, due to heavy optimizations for release builds.
+
+```shell
+cargo run --release
+```
+
+4. **Optional:** If you want to use your CPU features, you can set the `target-cpu=native` Rust compiler flag.
+```shell
+RUSTFLAGS='-C target-cpu=native' cargo run --release
+```
+
+## Docker
+
+> [!IMPORTANT]
+> Docker support is currently experimental.
+
+If you haven't already, you need to [install Docker](https://docs.docker.com/engine/install/). After installing Docker, you can run the following command to start the server:
+
+```shell
+docker run --rm \
+    -p <exposed_port>:25565  \
+    -v <server_data_location>:/pumpkin \
+    -it ghcr.io/pumpkin-mc/pumpkin:master
+```
+
+- `<exposed_port>`: The port you want to connect to Pumpkin with, for example `25565`.
+- `<server_data_location>`: The location where you want your server config and data to be stored, for example `./data`.
+
+### Example 
+
+To run Pumpkin on port `25565` and store data in a directory called `./data`, you would run the following command:
+```shell
+docker run --rm \
+    -p 25565:25565 \
+    -v ./data:/pumpkin \
+    -it ghcr.io/pumpkin-mc/pumpkin:master
+```
+
+## Test Server
+Pumpkin has a test server maintained by @kralverde. Its runs on the latest commit of Pumpkin's master branch.
+
+- **IP:** pumpkin.kralverde.dev
+
+**Specs:**
+- OS: Debian GNU/Linux bookworm 12.7 x86_64
+- Kernel: Linux 6.1.0-21-cloud-amd64
+- CPU: Intel Core (Haswell, no TSX) (2) @ 2.40 GHz
+- RAM: 4GB DIMM

--- a/docs/pt/about/quick-start.md
+++ b/docs/pt/about/quick-start.md
@@ -1,40 +1,42 @@
-# Quick Start
+# Primeiros Passos
 
-**Current Status:**
-Pre-release: Currently under development and not yet ready for official release.
+**Status Atual:**
+Pré-lançamento: Atualmente em desenvolvimento e ainda não pronto para lançamento oficial.
 
 ## Rust
 
-To run Pumpkin with Rust, ensure you have [Rust](https://www.rust-lang.org/tools/install) installed.
+Para rodar o Pumpkin com Rust, certifique-se de ter o [Rust](https://www.rust-lang.org/tools/install) instalado.
 
-1. Clone the repository:
+1. Clone o repositório:
+
 ```shell
 git clone https://github.com/Pumpkin-MC/Pumpkin.git
 cd Pumpkin
 ```
 
-2. **Optional:** If you wish, you can place a Vanilla world into the `Pumpkin/` directory. Just name the world folder `world`.
+2. **Opcional:** Se desejar, você pode colocar um mundo Vanilla no diretório `Pumpkin/`. Apenas nomeie a pasta do mundo como `world`.
 
-3. Run:
+3. Execute:
 
-> [!NOTE]
-> The build process may take a while, due to heavy optimizations for release builds.
+> [!NOTE] NOTA
+> O processo de construção pode demorar um pouco, devido a otimizações pesadas para builds de lançamento.
 
 ```shell
 cargo run --release
 ```
 
-4. **Optional:** If you want to use your CPU features, you can set the `target-cpu=native` Rust compiler flag.
+4. **Opcional:** Se quiser usar os recursos do seu processador, você pode configurar a flag do compilador Rust `target-cpu=native`.
+
 ```shell
 RUSTFLAGS='-C target-cpu=native' cargo run --release
 ```
 
 ## Docker
 
-> [!IMPORTANT]
-> Docker support is currently experimental.
+> [!IMPORTANT] IMPORTANTE
+> O suporte ao Docker está atualmente em fase experimental.
 
-If you haven't already, you need to [install Docker](https://docs.docker.com/engine/install/). After installing Docker, you can run the following command to start the server:
+Se ainda não tiver, você precisa [instalar o Docker](https://docs.docker.com/engine/install/). Após instalar o Docker, você pode rodar o seguinte comando para iniciar o servidor:
 
 ```shell
 docker run --rm \
@@ -43,12 +45,13 @@ docker run --rm \
     -it ghcr.io/pumpkin-mc/pumpkin:master
 ```
 
-- `<exposed_port>`: The port you want to connect to Pumpkin with, for example `25565`.
-- `<server_data_location>`: The location where you want your server config and data to be stored, for example `./data`.
+-   `<exposed_port>`: A porta que você deseja usar para conectar ao Pumpkin, por exemplo `25565`.
+-   `<server_data_location>`: O local onde você deseja que as configurações e dados do servidor sejam armazenados, por exemplo `./data`.
 
-### Example 
+### Exemplo
 
-To run Pumpkin on port `25565` and store data in a directory called `./data`, you would run the following command:
+Para rodar o Pumpkin na porta `25565` e armazenar os dados em um diretório chamado `./data`, você executaria o seguinte comando:
+
 ```shell
 docker run --rm \
     -p 25565:25565 \
@@ -56,13 +59,15 @@ docker run --rm \
     -it ghcr.io/pumpkin-mc/pumpkin:master
 ```
 
-## Test Server
-Pumpkin has a test server maintained by @kralverde. Its runs on the latest commit of Pumpkin's master branch.
+## Servidor de Teste
 
-- **IP:** pumpkin.kralverde.dev
+Pumpkin tem um servidor de teste mantido por @kralverde. Ele roda no commit mais recente da branch master do Pumpkin.
 
-**Specs:**
-- OS: Debian GNU/Linux bookworm 12.7 x86_64
-- Kernel: Linux 6.1.0-21-cloud-amd64
-- CPU: Intel Core (Haswell, no TSX) (2) @ 2.40 GHz
-- RAM: 4GB DIMM
+-   **IP:** pumpkin.kralverde.dev
+
+**Especificações:**
+
+-   SO: Debian GNU/Linux bookworm 12.7 x86_64
+-   Kernel: Linux 6.1.0-21-cloud-amd64
+-   CPU: Intel Core (Haswell, sem TSX) (2) @ 2.40 GHz
+-   RAM: 4GB DIMM

--- a/docs/pt/config/authentication.md
+++ b/docs/pt/config/authentication.md
@@ -1,160 +1,198 @@
-# Authentication
+# Autenticação
 
-Servers authenthicate with Mojang's session servers in order to ensure the client is playing on a legitimate, paid account. Pumpkin allows you to fully configure authentication.
+Servidores autenticam com os servidores de sessão da Mojang para garantir que o cliente esteja jogando em uma conta legítima e paga. O Pumpkin permite configurar a autenticação de forma completa.
 
-## Configuring Authentication
+## Configurando a Autenticação
 
-> [!WARNING]
-> Most servers should not change the default authenthication configuration. Doing so may have unintended consequnces. **Only change these settings if you know what you are doing!**
+> [!WARNING] AVISO
+> A maioria dos servidores não deve alterar a configuração padrão de autenticação. Fazer isso pode ter consequências indesejadas. **Altere essas configurações somente se souber o que está fazendo!**
 
-#### `enabled`: Boolean
+#### `enabled`: Booleano
 
-Whether authenthication is enabled or not.
+Define se a autenticação está habilitada ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [authentication]
 enabled = false
 ```
+
 :::
 
-#### `prevent_proxy_connections`: Boolean
+#### `prevent_proxy_connections`: Booleano
 
-Whether to block proxy connections or not.
+Define se deve bloquear conexões de proxy ou não.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [authentication]
 enabled = true
 prevent_proxy_connections = true
 ```
+
 :::
 
-#### `auth_url`: String (optional)
-The URL to authenthicate with. Uses Mojang's session servers to authenthicate if not specified. 
+#### `auth_url`: String (opcional)
 
-##### Placeholders
-| Placeholder     | Description        |
-| --------------- | ------------------ |
-| `{username}`    | Player username    |
-| `{server_hash}` | Hash of the server |
+A URL para autenticar. Usa os servidores de sessão da Mojang para autenticação se não for especificada.
+
+##### Argumentos
+
+| Argumento       | Descrição                  |
+| --------------- | -------------------------- |
+| `{username}`    | Nome de usuário do jogador |
+| `{server_hash}` | Hash do servidor           |
 
 :::code-group
+
 ```toml [features.toml] {2}
 [authentication]
-auth_url = "[custom auth server here]"
+auth_url = "[servidor de autenticação personalizado aqui]"
 ```
+
 :::
 
-#### `prevent_proxy_connection_auth_url`: String (optional)
-The URL to authenthicate with if `prevent_proxy_connections` is enabled. Uses Mojang's session servers to authenthicate if not specified.
+#### `prevent_proxy_connection_auth_url`: String (opcional)
 
-##### Placeholders
-| Placeholder     | Description              |
-| --------------- | ------------------------ |
-| `{username}`    | Player username          |
-| `{server_hash}` | Hash of the server       |
-| `{ip}`          | IP Address of the player |
+A URL para autenticar quando `prevent_proxy_connections` está habilitado. Usa os servidores de sessão da Mojang para autenticação se não for especificada.
+
+##### Argumentos
+
+| Argumento       | Descrição                  |
+| --------------- | -------------------------- |
+| `{username}`    | Nome de usuário do jogador |
+| `{server_hash}` | Hash do servidor           |
+| `{ip}`          | Endereço IP do jogador     |
 
 :::code-group
+
 ```toml [features.toml] {2}
 [authentication]
-prevent_proxy_connection_auth_url = "[custom auth server here]"
+prevent_proxy_connection_auth_url = "[servidor de autenticação personalizado aqui]"
 ```
+
 :::
 
-### Player Profile
+### Perfil do Jogador
 
-#### `allow_banned_players`: Boolean
-Allow players flagged by Mojang.
+#### `allow_banned_players`: Booleano
+
+Permitir jogadores banidos pela Mojang.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [authentication.player_profile]
 allow_banned_players = true
 ```
+
 :::
 
-#### `allowed_actions`: String Array
-What actions are allowed if `allow_banned_players` is enabled.
+#### `allowed_actions`: Array de Strings
+
+Quais ações são permitidas se `allow_banned_players` estiver habilitado.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [authentication.player_profile]
 allow_banned_players = true
 allowed_actions = ["FORCED_NAME_CHANGE", "USING_BANNED_SKIN"]
 ```
+
 :::
 
-### Textures
+### Texturas
 
-#### `enabled`: Boolean
-Whether to filter/validate player textures (e.g. skins/capes).
+#### `enabled`: Booleano
+
+Define se as texturas dos jogadores (por exemplo, skins/capas) devem ser filtradas/validadas.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [authentication.textures]
 enabled = true
 ```
+
 :::
 
-#### `allowed_url_schemes`: String Array
-Allowed URL schemes for textures.
+#### `allowed_url_schemes`: Array de Strings
+
+Esquemas URL permitidos para texturas.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [authentication.textures]
 enabled = true
 allowed_url_schemes = ["http", "https"]
 ```
+
 :::
 
-#### `allowed_url_domains`: String Array
-Allowed URL domains for textures.
+#### `allowed_url_domains`: Array de Strings
+
+Domínios URL permitidos para texturas.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [authentication.textures]
 enabled = true
 allowed_url_domains = [".minecraft.net", ".mojang.com"]
 ```
+
 :::
 
-### Texture Types
+### Tipos de Texturas
 
-#### `skin`: Boolean
-Whether to use player skins or not.
+#### `skin`: Booleano
+
+Define se deve usar skins dos jogadores ou não.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [authentication.textures.types]
 skin = true
 ```
+
 :::
 
-#### `cape`: Boolean
-Whether to use player capes or not.
+#### `cape`: Booleano
+
+Define se deve usar capas dos jogadores ou não.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [authentication.textures.types]
 cape = true
 ```
+
 :::
 
-#### `elytra`: Boolean
-Whether to use player elytras or not.
+#### `elytra`: Booleano
+
+Define se deve usar elytras dos jogadores ou não.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [authentication.textures.types]
 elytra = true
 ```
+
 :::
 
-## Default Config
-By default, authentication is enabled and uses Mojang's servers. Here is the default config:
+## Configuração Padrão
+
+Por padrão, a autenticação está habilitada e usa os servidores da Mojang. Aqui está a configuração padrão:
 :::code-group
+
 ```toml [features.toml]
 [authentication]
 enabled = true
@@ -174,4 +212,5 @@ skin = true
 cape = true
 elytra = true
 ```
+
 :::

--- a/docs/pt/config/authentication.md
+++ b/docs/pt/config/authentication.md
@@ -1,0 +1,177 @@
+# Authentication
+
+Servers authenthicate with Mojang's session servers in order to ensure the client is playing on a legitimate, paid account. Pumpkin allows you to fully configure authentication.
+
+## Configuring Authentication
+
+> [!WARNING]
+> Most servers should not change the default authenthication configuration. Doing so may have unintended consequnces. **Only change these settings if you know what you are doing!**
+
+#### `enabled`: Boolean
+
+Whether authenthication is enabled or not.
+
+:::code-group
+```toml [features.toml] {2}
+[authentication]
+enabled = false
+```
+:::
+
+#### `prevent_proxy_connections`: Boolean
+
+Whether to block proxy connections or not.
+
+:::code-group
+```toml [features.toml] {3}
+[authentication]
+enabled = true
+prevent_proxy_connections = true
+```
+:::
+
+#### `auth_url`: String (optional)
+The URL to authenthicate with. Uses Mojang's session servers to authenthicate if not specified. 
+
+##### Placeholders
+| Placeholder     | Description        |
+| --------------- | ------------------ |
+| `{username}`    | Player username    |
+| `{server_hash}` | Hash of the server |
+
+:::code-group
+```toml [features.toml] {2}
+[authentication]
+auth_url = "[custom auth server here]"
+```
+:::
+
+#### `prevent_proxy_connection_auth_url`: String (optional)
+The URL to authenthicate with if `prevent_proxy_connections` is enabled. Uses Mojang's session servers to authenthicate if not specified.
+
+##### Placeholders
+| Placeholder     | Description              |
+| --------------- | ------------------------ |
+| `{username}`    | Player username          |
+| `{server_hash}` | Hash of the server       |
+| `{ip}`          | IP Address of the player |
+
+:::code-group
+```toml [features.toml] {2}
+[authentication]
+prevent_proxy_connection_auth_url = "[custom auth server here]"
+```
+:::
+
+### Player Profile
+
+#### `allow_banned_players`: Boolean
+Allow players flagged by Mojang.
+
+:::code-group
+```toml [features.toml] {2}
+[authentication.player_profile]
+allow_banned_players = true
+```
+:::
+
+#### `allowed_actions`: String Array
+What actions are allowed if `allow_banned_players` is enabled.
+
+:::code-group
+```toml [features.toml] {3}
+[authentication.player_profile]
+allow_banned_players = true
+allowed_actions = ["FORCED_NAME_CHANGE", "USING_BANNED_SKIN"]
+```
+:::
+
+### Textures
+
+#### `enabled`: Boolean
+Whether to filter/validate player textures (e.g. skins/capes).
+
+:::code-group
+```toml [features.toml] {2}
+[authentication.textures]
+enabled = true
+```
+:::
+
+#### `allowed_url_schemes`: String Array
+Allowed URL schemes for textures.
+
+:::code-group
+```toml [features.toml] {3}
+[authentication.textures]
+enabled = true
+allowed_url_schemes = ["http", "https"]
+```
+:::
+
+#### `allowed_url_domains`: String Array
+Allowed URL domains for textures.
+
+:::code-group
+```toml [features.toml] {3}
+[authentication.textures]
+enabled = true
+allowed_url_domains = [".minecraft.net", ".mojang.com"]
+```
+:::
+
+### Texture Types
+
+#### `skin`: Boolean
+Whether to use player skins or not.
+
+:::code-group
+```toml [features.toml] {3}
+[authentication.textures.types]
+skin = true
+```
+:::
+
+#### `cape`: Boolean
+Whether to use player capes or not.
+
+:::code-group
+```toml [features.toml] {3}
+[authentication.textures.types]
+cape = true
+```
+:::
+
+#### `elytra`: Boolean
+Whether to use player elytras or not.
+
+:::code-group
+```toml [features.toml] {3}
+[authentication.textures.types]
+elytra = true
+```
+:::
+
+## Default Config
+By default, authentication is enabled and uses Mojang's servers. Here is the default config:
+:::code-group
+```toml [features.toml]
+[authentication]
+enabled = true
+prevent_proxy_connections = false
+
+[authentication.player_profile]
+allow_banned_players = false
+allowed_actions = ["FORCED_NAME_CHANGE", "USING_BANNED_SKIN"]
+
+[authentication.textures]
+enabled = true
+allowed_url_schemes = ["http", "https"]
+allowed_url_domains = [".minecraft.net", ".mojang.com"]
+
+[authentication.textures.types]
+skin = true
+cape = true
+elytra = true
+```
+:::

--- a/docs/pt/config/basic.md
+++ b/docs/pt/config/basic.md
@@ -1,0 +1,192 @@
+# Basic Configuration
+
+Representing `configuration.toml`
+
+## Server Address
+
+The address to bind the server to.
+
+:::code-group
+```toml [configuration.toml] {2}
+server_address = "0.0.0.0:25565"
+```
+:::
+
+## Seed
+
+The seed for world generation.
+
+:::code-group
+```toml [configuration.toml] {2}
+seed = ""
+```
+:::
+
+## Max players
+
+The maximum number of players allowed on the server.
+
+:::code-group
+```toml [configuration.toml] {2}
+max_players = 100000
+```
+:::
+
+## View distance
+
+The maximum view distance for players.
+
+:::code-group
+```toml [configuration.toml] {2}
+view_distance = 10
+```
+:::
+
+## Simulation distance
+
+The maximum simulation distance for players.
+
+:::code-group
+```toml [configuration.toml] {2}
+simulation_distance = 10
+```
+:::
+
+## Default difficulty
+
+The default game difficulty.
+
+:::code-group
+```toml [configuration.toml] {2}
+default_difficulty = "Normal"
+```
+:::
+
+
+```toml
+Peaceful
+Easy
+Normal
+Hard
+```
+
+## Operation permission level
+
+The permission level assigned by the `/op` command.
+
+:::code-group
+```toml [configuration.toml] {2}
+op_permission_level = 4
+```
+:::
+
+## Allow nether
+
+Whether the Nether dimension is enabled.
+
+:::code-group
+```toml [configuration.toml] {2}
+allow_nether = true
+```
+:::
+
+## Hardcore
+
+Whether the server is in hardcore mode.
+
+:::code-group
+```toml [configuration.toml] {2}
+hardcore = false
+```
+:::
+
+## Online Mode
+
+Whether online mode is enabled. Requires valid Minecraft accounts.
+
+:::code-group
+```toml [configuration.toml] {2}
+online_mode = true
+```
+:::
+
+## Encryption
+
+Whether packet encryption is enabled.
+
+> [!IMPORTANT]
+> Required when online mode is enabled.
+
+:::code-group
+```toml [configuration.toml] {2}
+encryption = true
+```
+:::
+
+## MOTD
+
+Message of the Day; the server's description displayed on the status screen.
+
+:::code-group
+```toml [configuration.toml] {2}
+motd = "A Blazing fast Pumpkin Server!"
+```
+:::
+
+## TPS
+
+The server's target tick rate.
+
+:::code-group
+```toml [configuration.toml] {2}
+tps = 20.0
+```
+:::
+
+## Default gamemode
+
+The default game mode for players.
+
+:::code-group
+```toml [configuration.toml] {2}
+default_gamemode = "Survival"
+```
+:::
+
+```toml
+Undefined
+Survival
+Creative
+Adventure
+Spectator
+```
+
+## IP Scrubbing
+
+Whether to scrub players' IP addresses from logs.
+
+:::code-group
+```toml [configuration.toml] {2}
+scrub_ips = true
+```
+:::
+
+## Use favicon
+
+Whether to use a server favicon or not.
+
+:::code-group
+```toml [configuration.toml] {2}
+use_favicon = true
+```
+:::
+
+## Favicon path
+
+The path to the server's favicon.
+
+:::code-group
+```toml [configuration.toml] {2}
+favicon_path = "icon.png"
+```
+:::

--- a/docs/pt/config/basic.md
+++ b/docs/pt/config/basic.md
@@ -1,67 +1,78 @@
-# Basic Configuration
+# Configuração Básica
 
-Representing `configuration.toml`
+Representando `configuration.toml`
 
-## Server Address
+## Endereço do Servidor
 
-The address to bind the server to.
+O endereço para vincular o servidor.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 server_address = "0.0.0.0:25565"
 ```
+
 :::
 
 ## Seed
 
-The seed for world generation.
+A seed para a geração do mundo.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 seed = ""
 ```
+
 :::
 
-## Max players
+## Limite de Jogadores
 
-The maximum number of players allowed on the server.
+O número máximo de jogadores permitidos no servidor.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 max_players = 100000
 ```
+
 :::
 
-## View distance
+## Distância de Visão
 
-The maximum view distance for players.
+A distância máxima de visão para os jogadores.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 view_distance = 10
 ```
+
 :::
 
-## Simulation distance
+## Distância de Simulação
 
-The maximum simulation distance for players.
+A distância máxima de simulação para os jogadores.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 simulation_distance = 10
 ```
+
 :::
 
-## Default difficulty
+## Dificuldade Padrão
 
-The default game difficulty.
+A dificuldade padrão do jogo.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 default_difficulty = "Normal"
 ```
-:::
 
+:::
 
 ```toml
 Peaceful
@@ -70,87 +81,103 @@ Normal
 Hard
 ```
 
-## Operation permission level
+## Nível de Permissão de Operação
 
-The permission level assigned by the `/op` command.
+O nível de permissão atribuído pelo comando `/op`.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 op_permission_level = 4
 ```
+
 :::
 
-## Allow nether
+## Permitir Nether
 
-Whether the Nether dimension is enabled.
+Se a dimensão Nether está habilitada.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 allow_nether = true
 ```
+
 :::
 
 ## Hardcore
 
-Whether the server is in hardcore mode.
+Se o servidor está no modo hardcore.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 hardcore = false
 ```
+
 :::
 
-## Online Mode
+## Modo Online
 
-Whether online mode is enabled. Requires valid Minecraft accounts.
+Se o modo online está habilitado. Requer contas válidas do Minecraft.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 online_mode = true
 ```
+
 :::
 
-## Encryption
+## Criptografia
 
-Whether packet encryption is enabled.
+Se a criptografia de pacotes está habilitada.
 
-> [!IMPORTANT]
-> Required when online mode is enabled.
+> [!IMPORTANTE]
+> Requerido quando o modo online está habilitado.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 encryption = true
 ```
+
 :::
 
 ## MOTD
 
-Message of the Day; the server's description displayed on the status screen.
+Mensagem do Dia; a descrição do servidor exibida na tela de status.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 motd = "A Blazing fast Pumpkin Server!"
 ```
+
 :::
 
 ## TPS
 
-The server's target tick rate.
+A taxa de tique (tick rate) alvo do servidor.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 tps = 20.0
 ```
+
 :::
 
-## Default gamemode
+## Modo de Jogo Padrão
 
-The default game mode for players.
+O modo de jogo padrão para os jogadores.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 default_gamemode = "Survival"
 ```
+
 :::
 
 ```toml
@@ -161,32 +188,38 @@ Adventure
 Spectator
 ```
 
-## IP Scrubbing
+## Limpeza de IPs
 
-Whether to scrub players' IP addresses from logs.
+Se os endereços IP dos jogadores devem ser removidos dos logs.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 scrub_ips = true
 ```
+
 :::
 
-## Use favicon
+## Usar Favicon
 
-Whether to use a server favicon or not.
+Se o servidor deve usar um favicon ou não.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 use_favicon = true
 ```
+
 :::
 
-## Favicon path
+## Caminho do Favicon
 
-The path to the server's favicon.
+O caminho para o favicon do servidor.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 favicon_path = "icon.png"
 ```
+
 :::

--- a/docs/pt/config/commands.md
+++ b/docs/pt/config/commands.md
@@ -1,0 +1,46 @@
+# Commands
+Pumpkin supports Vanilla commands and allows you to configure where they can be ran from. 
+
+## Configuring Commands
+#### `use_console`: Boolean
+Whether commands from the console are accepted or not.
+
+:::code-group
+```toml [features.toml] {2}
+[commands]
+use_console = false
+```
+:::
+
+#### `log_console`: Boolean
+Whether commands from players should be logged in the console or not.
+
+:::code-group
+```toml [features.toml] {2}
+[commands]
+log_console = false
+```
+:::
+
+## Operation permission level
+
+The default permission level for all players.
+
+:::code-group
+```toml [configuration.toml] {2}
+default_op_level = 0
+```
+:::
+
+
+## Default Config
+By default, Pumpkin will allow commands from console and log all commands run by players.
+
+:::code-group
+```toml [features.toml]
+[commands]
+use_console = true
+log_console = true
+default_op_level = 0
+```
+:::

--- a/docs/pt/config/commands.md
+++ b/docs/pt/config/commands.md
@@ -1,46 +1,58 @@
-# Commands
-Pumpkin supports Vanilla commands and allows you to configure where they can be ran from. 
+# Comandos
 
-## Configuring Commands
-#### `use_console`: Boolean
-Whether commands from the console are accepted or not.
+Pumpkin suporta comandos Vanilla e permite configurar onde eles podem ser executados.
+
+## Configurando Comandos
+
+#### `use_console`: Booleano
+
+Se os comandos do console são aceitos ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [commands]
 use_console = false
 ```
+
 :::
 
-#### `log_console`: Boolean
-Whether commands from players should be logged in the console or not.
+#### `log_console`: Booleano
+
+Se os comandos dos jogadores devem ser registrados no console ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [commands]
 log_console = false
 ```
+
 :::
 
-## Operation permission level
+## Nível de permissão de operação
 
-The default permission level for all players.
+O nível de permissão padrão para todos os jogadores.
 
 :::code-group
+
 ```toml [configuration.toml] {2}
 default_op_level = 0
 ```
+
 :::
 
+## Configuração Padrão
 
-## Default Config
-By default, Pumpkin will allow commands from console and log all commands run by players.
+Por padrão, Pumpkin permitirá comandos da console e registrará todos os comandos executados pelos jogadores.
 
 :::code-group
+
 ```toml [features.toml]
 [commands]
 use_console = true
 log_console = true
 default_op_level = 0
 ```
+
 :::

--- a/docs/pt/config/compression.md
+++ b/docs/pt/config/compression.md
@@ -1,55 +1,65 @@
-# Compression
-Compression is used to reduce the size of packets. This is beneficial to reduce bandwidth server side and also to help players on slower internet connections.
+# Compressão
 
-## Configuring compression
+A compressão é utilizada para reduzir o tamanho dos pacotes. Isso é benéfico para reduzir a largura de banda do lado do servidor e também para ajudar jogadores com conexões de internet mais lentas.
 
-#### `enabled`: Boolean
-Whether packet compression is enabled or not.
+## Configurando a compressão
 
-> [!TIP]
-> It might be beneficial to disable compression if the server is behind a proxy.
+#### `enabled`: Booleano
+
+Se a compressão de pacotes está habilitada ou não.
+
+> [!TIP] DICA
+> Pode ser benéfico desabilitar a compressão se o servidor estiver atrás de um proxy.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [packet_compression]
 enabled = true
 ```
+
 :::
 
-#### `threshold`: Integer (0-1024)
+#### `threshold`: Inteiro (0-1024)
 
-The minimum packet size before the server attempts to compress the packet.
+O tamanho mínimo do pacote antes que o servidor tente comprimir o pacote.
 
-> [!CAUTION]
-> Increasing this value can hurt players on slower connections.
+> [!CAUTION] CUIDADO
+> Aumentar este valor pode prejudicar jogadores com conexões mais lentas.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [packet_compression]
 threshold = 256
 ```
+
 :::
 
-#### `level`: Integer (0-9)
+#### `level`: Inteiro (0-9)
 
-A value between 0 to 9: 0 to disable compression, 1 being the fastest compression (at the cost of size), and 9 being maximum compression (at the cost of speed).
+Um valor entre 0 e 9: 0 para desabilitar a compressão, 1 sendo a compressão mais rápida (à custa do tamanho), e 9 sendo a compressão máxima (à custa da velocidade).
 
 :::code-group
+
 ```toml [features.toml] {2}
 [packet_compression]
 level = 4
 ```
+
 :::
 
-## Default config
+## Configuração Padrão
 
-By default, compression is enabled.
+Por padrão, a compressão está habilitada.
 
 :::code-group
+
 ```toml [features.toml]
 [packet_compression]
 enabled = true
 threshold = 256
 level = 4
 ```
+
 :::

--- a/docs/pt/config/compression.md
+++ b/docs/pt/config/compression.md
@@ -1,0 +1,55 @@
+# Compression
+Compression is used to reduce the size of packets. This is beneficial to reduce bandwidth server side and also to help players on slower internet connections.
+
+## Configuring compression
+
+#### `enabled`: Boolean
+Whether packet compression is enabled or not.
+
+> [!TIP]
+> It might be beneficial to disable compression if the server is behind a proxy.
+
+:::code-group
+```toml [features.toml] {2}
+[packet_compression]
+enabled = true
+```
+:::
+
+#### `threshold`: Integer (0-1024)
+
+The minimum packet size before the server attempts to compress the packet.
+
+> [!CAUTION]
+> Increasing this value can hurt players on slower connections.
+
+:::code-group
+```toml [features.toml] {2}
+[packet_compression]
+threshold = 256
+```
+:::
+
+#### `level`: Integer (0-9)
+
+A value between 0 to 9: 0 to disable compression, 1 being the fastest compression (at the cost of size), and 9 being maximum compression (at the cost of speed).
+
+:::code-group
+```toml [features.toml] {2}
+[packet_compression]
+level = 4
+```
+:::
+
+## Default config
+
+By default, compression is enabled.
+
+:::code-group
+```toml [features.toml]
+[packet_compression]
+enabled = true
+threshold = 256
+level = 4
+```
+:::

--- a/docs/pt/config/introduction.md
+++ b/docs/pt/config/introduction.md
@@ -1,0 +1,23 @@
+### Configuration
+
+Pumpkin offers a robust configuration system that allows users to customize various aspects of the server's behavior without relying on external plugins. This provides flexibility and control over the server's operation.
+
+### Basic / Advanced
+
+Pumpkin's configuration is split into a "basic" configuration made for quick changes and important changes, and a more "advanced" configuration
+
+- `configuration.toml`: simple and can be compared to the vanilla `server.properties`.
+- `features.toml`: designed to have all features of pumpkin at one place, making it a large configuration
+
+### Server Version
+
+Pumpkin aims to support the latest Minecraft Version. If you want to host a Pumpkin server for any other version, there is a project called [ViaProxy](https://github.com/ViaVersion/ViaProxy).
+
+- Make sure to allow proxy connections.
+- Pumpkin and ViaProxy have no connection; don't submit issues regarding their code. Furthermore, this is a 3rd party proxy and Pumpkin does not take any responsibility for the good or the bad.
+
+#### Key Features:
+
+- Extensive Customization: Configure server settings, player behavior, world generation, and more.
+- Performance Optimization: Optimize server performance through configuration tweaks.
+- Plugin-Free Customization: Achieve desired changes without the need for additional plugins.

--- a/docs/pt/config/introduction.md
+++ b/docs/pt/config/introduction.md
@@ -1,23 +1,23 @@
-### Configuration
+### Configuração
 
-Pumpkin offers a robust configuration system that allows users to customize various aspects of the server's behavior without relying on external plugins. This provides flexibility and control over the server's operation.
+Pumpkin oferece um sistema de configuração robusto que permite aos usuários personalizar vários aspectos do comportamento do servidor sem depender de plugins externos. Isso proporciona flexibilidade e controle sobre o funcionamento do servidor.
 
-### Basic / Advanced
+### Básica / Avançada
 
-Pumpkin's configuration is split into a "basic" configuration made for quick changes and important changes, and a more "advanced" configuration
+A configuração do Pumpkin é dividida em uma configuração "básica", feita para mudanças rápidas e importantes, e uma configuração mais "avançada".
 
-- `configuration.toml`: simple and can be compared to the vanilla `server.properties`.
-- `features.toml`: designed to have all features of pumpkin at one place, making it a large configuration
+-   `configuration.toml`: simples e pode ser comparado ao `server.properties` do vanilla.
+-   `features.toml`: projetado para reunir todos os recursos do Pumpkin em um único lugar, tornando-se uma configuração mais abrangente.
 
-### Server Version
+### Versão do Servidor
 
-Pumpkin aims to support the latest Minecraft Version. If you want to host a Pumpkin server for any other version, there is a project called [ViaProxy](https://github.com/ViaVersion/ViaProxy).
+Pumpkin tem como objetivo oferecer suporte à versão mais recente do Minecraft. Se você deseja hospedar um servidor Pumpkin para qualquer outra versão, existe um projeto chamado [ViaProxy](https://github.com/ViaVersion/ViaProxy).
 
-- Make sure to allow proxy connections.
-- Pumpkin and ViaProxy have no connection; don't submit issues regarding their code. Furthermore, this is a 3rd party proxy and Pumpkin does not take any responsibility for the good or the bad.
+-   Certifique-se de permitir conexões de proxy.
+-   Pumpkin e o ViaProxy não possuem conexão; não nos envie problemas relacionados ao código deles. Além disso, este é um proxy de terceiros e o Pumpkin não se responsabiliza pelos resultados, bons ou ruins.
 
-#### Key Features:
+#### Principais Características:
 
-- Extensive Customization: Configure server settings, player behavior, world generation, and more.
-- Performance Optimization: Optimize server performance through configuration tweaks.
-- Plugin-Free Customization: Achieve desired changes without the need for additional plugins.
+-   **Personalização Extensa**: Configure configurações do servidor, comportamento dos jogadores, geração de mundos e muito mais.
+-   **Otimização de Desempenho**: Otimize o desempenho do servidor por meio de ajustes na configuração.
+-   **Personalização Sem Plugins**: Alcance as mudanças desejadas sem a necessidade de plugins adicionais.

--- a/docs/pt/config/lan-broadcast.md
+++ b/docs/pt/config/lan-broadcast.md
@@ -1,0 +1,54 @@
+# LAN Broadcast
+Pumpkin can advertise the server across the network in order to make it easier for local players to connect to the server easier.
+
+## Configuring LAN Broadcast
+
+#### `enabled`: Boolean
+Whether LAN broadcast is enabled or not.
+
+:::code-group
+```toml [features.toml] {2}
+[lan_broadcast]
+enabled = true
+```
+:::
+
+#### `motd`: String (optional)
+The MOTD to broadcast out to clients; uses the server's MOTD by default.
+
+> [!CAUTION]
+> LAN broadcast MOTD does not support multiple lines, RGB colors, or gradients. Pumpkin does not verify the MOTD before broadcasting it. If the server MOTD is using these components, consider defining this field so that clients see a proper MOTD.
+
+:::code-group
+```toml [features.toml] {3}
+[lan_broadcast]
+enabled = true
+motd = "[your MOTD here]"
+```
+:::
+
+#### `port`: Integer (0-65535) (optional)
+What port to bind to. If not specified, will bind to port 0 (any available port on the system).
+
+> [!IMPORTANT]
+> The protocol defines what port to broadcast to. This option only exists to specify which port to bind to on the host. This option purely exists so that the port can be predictable.
+
+:::code-group
+```toml [features.toml] {3}
+[lan_broadcast]
+enabled = true
+port = 46733
+```
+:::
+
+## Default Config
+By default, LAN broadcast is disabled.
+
+:::code-group
+```toml [features.toml]
+[lan_broadcast]
+enabled = false
+motd = "[server MOTD here]"
+port = 0
+```
+:::

--- a/docs/pt/config/lan-broadcast.md
+++ b/docs/pt/config/lan-broadcast.md
@@ -1,54 +1,67 @@
-# LAN Broadcast
-Pumpkin can advertise the server across the network in order to make it easier for local players to connect to the server easier.
+# Transmissão LAN
 
-## Configuring LAN Broadcast
+Pumpkin pode divulgar o servidor na rede para facilitar a conexão de jogadores locais ao servidor.
 
-#### `enabled`: Boolean
-Whether LAN broadcast is enabled or not.
+## Configurando a Transmissão LAN
+
+#### `enabled`: Booleano
+
+Se a transmissão LAN está habilitada ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [lan_broadcast]
 enabled = true
 ```
+
 :::
 
-#### `motd`: String (optional)
-The MOTD to broadcast out to clients; uses the server's MOTD by default.
+#### `motd`: String (opcional)
 
-> [!CAUTION]
-> LAN broadcast MOTD does not support multiple lines, RGB colors, or gradients. Pumpkin does not verify the MOTD before broadcasting it. If the server MOTD is using these components, consider defining this field so that clients see a proper MOTD.
+A mensagem de boas-vindas (MOTD) a ser transmitida para os clientes; usa a MOTD do servidor por padrão.
+
+> [!CAUTION] CUIDADO
+> A MOTD da transmissão LAN não suporta múltiplas linhas, cores RGB ou gradientes. O Pumpkin não verifica a MOTD antes de transmiti-la. Se a MOTD do servidor usar esses componentes, considere definir este campo para que os clientes vejam uma MOTD adequada.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [lan_broadcast]
 enabled = true
-motd = "[your MOTD here]"
+motd = "[sua MOTD aqui]"
 ```
+
 :::
 
-#### `port`: Integer (0-65535) (optional)
-What port to bind to. If not specified, will bind to port 0 (any available port on the system).
+#### `port`: Inteiro (0-65535) (opcional)
 
-> [!IMPORTANT]
-> The protocol defines what port to broadcast to. This option only exists to specify which port to bind to on the host. This option purely exists so that the port can be predictable.
+A porta para a qual o servidor será vinculado. Se não especificado, será vinculado à porta 0 (qualquer porta disponível no sistema).
+
+> [!IMPORTANT] IMPORTANTE
+> O protocolo define qual porta será usada para a transmissão. Esta opção existe apenas para especificar qual porta vincular no host. Ela existe exclusivamente para que a porta seja previsível.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [lan_broadcast]
 enabled = true
 port = 46733
 ```
+
 :::
 
-## Default Config
-By default, LAN broadcast is disabled.
+## Configuração Padrão
+
+Por padrão, a transmissão LAN está desabilitada.
 
 :::code-group
+
 ```toml [features.toml]
 [lan_broadcast]
 enabled = false
-motd = "[server MOTD here]"
+motd = "[MOTD do servidor aqui]"
 port = 0
 ```
+
 :::

--- a/docs/pt/config/logging.md
+++ b/docs/pt/config/logging.md
@@ -1,83 +1,105 @@
-# Logging
-Pumpkin allows you to customize what you want in your logs.
+# Registro de Logs
 
-## Configuring Logging
+Pumpkin permite personalizar o que você deseja registrar em seus logs.
 
-#### `enabled`: Boolean
-Whether logging is enabled or not.
+## Configurando o Registro de Logs
+
+#### `enabled`: Booleano
+
+Se o registro de logs está habilitado ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [logging]
 enabled = true
 ```
+
 :::
 
 #### `level`: Enum
-The log verbosity level. Possible values are:
-- Off
-- Error
-- Warn
-- Info
-- Debug
-- Trace
+
+O nível de verbosidade do log. Os valores possíveis são:
+
+-   Off (Desligado)
+-   Error (Erro)
+-   Warn (Aviso)
+-   Info (Informação)
+-   Debug (Depuração)
+-   Trace (Rastreamento)
 
 :::code-group
+
 ```toml [features.toml] {3}
 [logging]
 enabled = true
 level = "Debug"
 ```
+
 :::
 
-#### `env`: Boolean
-Whether to allow choosing the log level by setting the `RUST_LOG` environment variable or not.
+#### `env`: Booleano
+
+Se deve permitir escolher o nível de log configurando a variável de ambiente `RUST_LOG` ou não.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [logging]
 enabled = true
 env = true
 ```
+
 :::
 
-#### `threads`: Boolean
-Whether to print threads in the logging message or not.
+#### `threads`: Booleano
+
+Se deve exibir as threads nas mensagens de log ou não.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [logging]
 enabled = true
 threads = false
 ```
+
 :::
 
-#### `color`: Boolean
-Whether to print to the console with color or not.
+#### `color`: Booleano
+
+Se deve imprimir no console com cores ou não.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [logging]
 enabled = true
 color = false
 ```
+
 :::
 
-#### `timestamp`: Boolean
-Whether to print the timestamp in the message or not.
+#### `timestamp`: Booleano
+
+Se deve imprimir a data e hora na mensagem ou não.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [logging]
 enabled = true
 timestamp = false
 ```
+
 :::
 
-## Default Config
-By default, logging is enabled at the `Info` level and will print with color, threads, and timestamps. 
+## Configuração Padrão
+
+Por padrão, o registro de logs está habilitado no nível `Info` e imprimirá com cores, threads e data/hora.
 
 :::code-group
+
 ```toml [features.toml]
 [logging]
 enabled = true
@@ -87,4 +109,5 @@ threads = true
 color = true
 timestamp = true
 ```
+
 :::

--- a/docs/pt/config/logging.md
+++ b/docs/pt/config/logging.md
@@ -1,0 +1,90 @@
+# Logging
+Pumpkin allows you to customize what you want in your logs.
+
+## Configuring Logging
+
+#### `enabled`: Boolean
+Whether logging is enabled or not.
+
+:::code-group
+```toml [features.toml] {2}
+[logging]
+enabled = true
+```
+:::
+
+#### `level`: Enum
+The log verbosity level. Possible values are:
+- Off
+- Error
+- Warn
+- Info
+- Debug
+- Trace
+
+:::code-group
+```toml [features.toml] {3}
+[logging]
+enabled = true
+level = "Debug"
+```
+:::
+
+#### `env`: Boolean
+Whether to allow choosing the log level by setting the `RUST_LOG` environment variable or not.
+
+:::code-group
+```toml [features.toml] {3}
+[logging]
+enabled = true
+env = true
+```
+:::
+
+#### `threads`: Boolean
+Whether to print threads in the logging message or not.
+
+:::code-group
+```toml [features.toml] {3}
+[logging]
+enabled = true
+threads = false
+```
+:::
+
+#### `color`: Boolean
+Whether to print to the console with color or not.
+
+:::code-group
+```toml [features.toml] {3}
+[logging]
+enabled = true
+color = false
+```
+:::
+
+#### `timestamp`: Boolean
+Whether to print the timestamp in the message or not.
+
+:::code-group
+```toml [features.toml] {3}
+[logging]
+enabled = true
+timestamp = false
+```
+:::
+
+## Default Config
+By default, logging is enabled at the `Info` level and will print with color, threads, and timestamps. 
+
+:::code-group
+```toml [features.toml]
+[logging]
+enabled = true
+level = "Info"
+env = false
+threads = true
+color = true
+timestamp = true
+```
+:::

--- a/docs/pt/config/proxy.md
+++ b/docs/pt/config/proxy.md
@@ -1,0 +1,78 @@
+# Proxy
+Many servers use proxies to manage connections and distribute players across servers. Pumpkin supports the following proxy protocols:
+
+- [Velocity](https://papermc.io/software/velocity)
+- [BungeeCord](https://www.spigotmc.org/wiki/bungeecord-installation/)
+
+> [!TIP]
+> Velocity is recommended for most server networks. Velocity is modern and more performant compared to BungeeCord.
+
+## Configuring Proxy
+
+#### `enabled`: Boolean
+
+Enables support for proxies.
+
+:::code-group
+```toml [features.toml]{2}
+[proxy]
+enabled = true
+```
+:::
+
+### Velocity
+
+#### `enabled`: Boolean
+
+Whether Velocity support is enabled or not.
+
+:::code-group
+```toml [features.toml]{2}
+[proxy.velocity]
+enabled = true
+```
+:::
+
+#### `secret`: String 
+
+The secret as configured in Velocity. 
+
+:::code-group
+```toml [features.toml]{3}
+[proxy.velocity]
+enabled = true
+secret = "[proxy secret here]"
+```
+:::
+
+### BungeeCord
+
+#### `enabled`: Boolean
+Whether BungeeCord support is enabled or not.
+
+:::code-group
+```toml [features.toml]{2}
+[proxy.bungeecord]
+enabled = true
+```
+:::
+
+> [!CAUTION]
+> BungeeCord can't verify if player info is from your proxy or an imposter. Ensure that the server's firewall is correctly configured.
+
+## Default Config
+By default, proxy support is disabled. Here is the default config:
+
+:::code-group
+```toml [features.toml]
+[proxy]
+enabled = false
+
+[proxy.velocity]
+enabled = false
+secret = ""
+
+[proxy.bungeecord]
+enabled = false
+```
+:::

--- a/docs/pt/config/proxy.md
+++ b/docs/pt/config/proxy.md
@@ -1,69 +1,81 @@
 # Proxy
-Many servers use proxies to manage connections and distribute players across servers. Pumpkin supports the following proxy protocols:
 
-- [Velocity](https://papermc.io/software/velocity)
-- [BungeeCord](https://www.spigotmc.org/wiki/bungeecord-installation/)
+Muitos servidores utilizam proxies para gerenciar conexões e distribuir jogadores entre servidores. Pumpkin suporta os seguintes protocolos de proxy:
 
-> [!TIP]
-> Velocity is recommended for most server networks. Velocity is modern and more performant compared to BungeeCord.
+-   [Velocity](https://papermc.io/software/velocity)
+-   [BungeeCord](https://www.spigotmc.org/wiki/bungeecord-installation/)
 
-## Configuring Proxy
+> [!TIP] DICA
+> Velocity é recomendado para a maioria das redes de servidores. Velocity é moderno e mais eficiente em comparação ao BungeeCord.
 
-#### `enabled`: Boolean
+## Configurando Proxy
 
-Enables support for proxies.
+#### `enabled`: Booleano
+
+Habilita o suporte para proxies.
 
 :::code-group
+
 ```toml [features.toml]{2}
 [proxy]
 enabled = true
 ```
+
 :::
 
 ### Velocity
 
-#### `enabled`: Boolean
+#### `enabled`: Booleano
 
-Whether Velocity support is enabled or not.
+Se o suporte ao Velocity está habilitado ou não.
 
 :::code-group
+
 ```toml [features.toml]{2}
 [proxy.velocity]
 enabled = true
 ```
+
 :::
 
-#### `secret`: String 
+#### `secret`: String
 
-The secret as configured in Velocity. 
+O segredo configurado no Velocity.
 
 :::code-group
+
 ```toml [features.toml]{3}
 [proxy.velocity]
 enabled = true
-secret = "[proxy secret here]"
+secret = "[segredo do proxy aqui]"
 ```
+
 :::
 
 ### BungeeCord
 
-#### `enabled`: Boolean
-Whether BungeeCord support is enabled or not.
+#### `enabled`: Booleano
+
+Se o suporte ao BungeeCord está habilitado ou não.
 
 :::code-group
+
 ```toml [features.toml]{2}
 [proxy.bungeecord]
 enabled = true
 ```
+
 :::
 
-> [!CAUTION]
-> BungeeCord can't verify if player info is from your proxy or an imposter. Ensure that the server's firewall is correctly configured.
+> [!CAUTION] CUIDADO
+> BungeeCord não consegue verificar se as informações do jogador são provenientes do seu proxy ou de um impostor. Certifique-se de que o firewall do servidor esteja configurado corretamente.
 
-## Default Config
-By default, proxy support is disabled. Here is the default config:
+## Configuração Padrão
+
+Por padrão, o suporte a proxies está desativado. Aqui está a configuração padrão:
 
 :::code-group
+
 ```toml [features.toml]
 [proxy]
 enabled = false
@@ -75,4 +87,5 @@ secret = ""
 [proxy.bungeecord]
 enabled = false
 ```
+
 :::

--- a/docs/pt/config/pvp.md
+++ b/docs/pt/config/pvp.md
@@ -1,62 +1,80 @@
 # PVP
-PVP is a core part of the Vanilla mechanics, with even the smallest change affecting gameplay. Pumpkin allows you to fully configure PVP.
 
-## Configuring PVP
+O PVP é uma parte fundamental da mecânica Vanilla, com até mesmo a menor mudança afetando a jogabilidade. Pumpkin permite que você configure completamente o PVP.
 
-#### `enabled`: Boolean
-Whether PVP is enabled or not.
+## Configurando o PVP
+
+#### `enabled`: Booleano
+
+Se o PVP está habilitado ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [pvp]
 enabled = true
 ```
+
 :::
 
-#### `hurt_animation`: Boolean
-Whether to show red hurt animation and FOV bobbing or not.
+#### `hurt_animation`: Booleano
+
+Se deve exibir a animação de dano vermelho e o movimento de câmera (FOV) ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [pvp]
 hurt_animation = true
 ```
+
 :::
 
-#### `protect_creative`: Boolean
-Whether to protect players in creative against PVP or not.
+#### `protect_creative`: Booleano
+
+Se deve proteger jogadores no modo criativo contra o PVP ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [pvp]
 protect_creative = true
 ```
+
 :::
 
-#### `knockback`: Boolean
-Whether attacks should have knockback or not.
+#### `knockback`: Booleano
+
+Se os ataques devem ter repulsão (knockback) ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [pvp]
 knockback = true
 ```
+
 :::
 
-#### `swing`: Boolean
-Whether players should swing when attacking or not.
+#### `swing`: Booleano
+
+Se os jogadores devem balançar a arma ao atacar ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [pvp]
 swing = true
 ```
+
 :::
 
-## Default Config
-By default, all PVP options are enabled in order to match vanilla behavior.
+## Configuração Padrão
+
+Por padrão, todas as opções de PVP estão habilitadas para coincidir com o comportamento Vanilla.
 
 :::code-group
+
 ```toml [features.toml]
 [pvp]
 enabled = true
@@ -65,4 +83,5 @@ protect_creative = true
 knockback = true
 swing = true
 ```
+
 :::

--- a/docs/pt/config/pvp.md
+++ b/docs/pt/config/pvp.md
@@ -1,0 +1,68 @@
+# PVP
+PVP is a core part of the Vanilla mechanics, with even the smallest change affecting gameplay. Pumpkin allows you to fully configure PVP.
+
+## Configuring PVP
+
+#### `enabled`: Boolean
+Whether PVP is enabled or not.
+
+:::code-group
+```toml [features.toml] {2}
+[pvp]
+enabled = true
+```
+:::
+
+#### `hurt_animation`: Boolean
+Whether to show red hurt animation and FOV bobbing or not.
+
+:::code-group
+```toml [features.toml] {2}
+[pvp]
+hurt_animation = true
+```
+:::
+
+#### `protect_creative`: Boolean
+Whether to protect players in creative against PVP or not.
+
+:::code-group
+```toml [features.toml] {2}
+[pvp]
+protect_creative = true
+```
+:::
+
+#### `knockback`: Boolean
+Whether attacks should have knockback or not.
+
+:::code-group
+```toml [features.toml] {2}
+[pvp]
+knockback = true
+```
+:::
+
+#### `swing`: Boolean
+Whether players should swing when attacking or not.
+
+:::code-group
+```toml [features.toml] {2}
+[pvp]
+swing = true
+```
+:::
+
+## Default Config
+By default, all PVP options are enabled in order to match vanilla behavior.
+
+:::code-group
+```toml [features.toml]
+[pvp]
+enabled = true
+hurt_animation = true
+protect_creative = true
+knockback = true
+swing = true
+```
+:::

--- a/docs/pt/config/query.md
+++ b/docs/pt/config/query.md
@@ -1,36 +1,46 @@
 # Query
-The Query protocol is a simple way to query the server about its status. Pumpkin fully supports the Query protocol.
 
-## Configuring Query
+O protocolo Query é uma maneira simples de consultar o status do servidor. Pumpkin oferece suporte total para o protocolo Query.
 
-#### `enabled`: Boolean
-Whether to listen for Query protocol requests or not.
+## Configurando o Query
+
+#### `enabled`: Booleano
+
+Se deve ouvir ou não as requisições do protocolo Query.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [query]
 enabled = true
 ```
+
 :::
 
-#### `port`: Integer (0-65535) (optional)
-Which port to listen to Query protocol requests on. If not specified, it uses the same port as the server.
+#### `port`: Inteiro (0-65535) (opcional)
+
+A porta em que o servidor deve ouvir as requisições do protocolo Query. Se não especificado, será utilizada a mesma porta do servidor.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [query]
 enabled = true
 port = 12345
 ```
+
 :::
 
-## Default Config
-By default, Query is disabled. It will run on the server port if enabled unless specified explicitly.
+## Configuração Padrão
+
+Por padrão, o Query está desabilitado. Ele será executado na porta do servidor se habilitado, a menos que especificado explicitamente.
 
 :::code-group
+
 ```toml [features.toml]
 [query]
 enabled = true
 port = 25565
 ```
+
 :::

--- a/docs/pt/config/query.md
+++ b/docs/pt/config/query.md
@@ -1,0 +1,36 @@
+# Query
+The Query protocol is a simple way to query the server about its status. Pumpkin fully supports the Query protocol.
+
+## Configuring Query
+
+#### `enabled`: Boolean
+Whether to listen for Query protocol requests or not.
+
+:::code-group
+```toml [features.toml] {2}
+[query]
+enabled = true
+```
+:::
+
+#### `port`: Integer (0-65535) (optional)
+Which port to listen to Query protocol requests on. If not specified, it uses the same port as the server.
+
+:::code-group
+```toml [features.toml] {3}
+[query]
+enabled = true
+port = 12345
+```
+:::
+
+## Default Config
+By default, Query is disabled. It will run on the server port if enabled unless specified explicitly.
+
+:::code-group
+```toml [features.toml]
+[query]
+enabled = true
+port = 25565
+```
+:::

--- a/docs/pt/config/rcon.md
+++ b/docs/pt/config/rcon.md
@@ -1,0 +1,106 @@
+# RCON
+RCON is a protocol that allows you to remotely manage the server from a different device. Pumpkin has full support for RCON.
+
+## Configuring RCON
+
+#### `enabled`: Boolean
+
+:::code-group
+```toml [features.toml] {2}
+[rcon]
+enabled = true
+```
+:::
+
+#### `address`: String
+The address and port that RCON should listen to.
+
+:::code-group
+```toml [features.toml] {3}
+[rcon]
+enabled = true
+address = "0.0.0.0:25575"
+```
+:::
+
+#### `password`: String
+The password to use for RCON authentication.
+
+:::code-group
+```toml [features.toml] {3}
+[rcon]
+enabled = true
+password = "[your safe password here]"
+```
+:::
+
+#### `max_connections`: Integer
+The max number of RCON connections allowed at a single time. Set this to 0 to disable the limit.
+
+:::code-group
+```toml [features.toml] {3}
+[rcon]
+enabled = true
+max_connections = 5
+```
+:::
+
+### Logging
+#### `log_logged_successfully`: Boolean
+Whether successful logins should be logged to console or not.
+
+:::code-group
+```toml [features.toml] {2}
+[rcon.logging]
+log_logged_successfully = true
+```
+:::
+
+#### `log_wrong_password`: Boolean
+Whether wrong password attempts should be logged to console or not.
+
+:::code-group
+```toml [features.toml] {2}
+[rcon.logging]
+log_logged_successfully = true
+```
+:::
+
+#### `log_commands`: Boolean
+Whether to log commands ran from RCON to console or not.
+
+:::code-group
+```toml [features.toml] {2}
+[rcon.logging]
+log_commands = true
+```
+:::
+
+#### `log_quit`: Boolean
+Whether RCON client quit should be logged or not.
+
+:::code-group
+```toml [features.toml] {2}
+[rcon.logging]
+log_quit = true
+```
+:::
+
+## Default Config
+By default, RCON is disabled.
+
+:::code-group
+```toml [features.toml]
+[rcon]
+enabled = false
+address = "0.0.0.0:25575"
+password = ""
+max_connections = 0
+
+[rcon.logging]
+log_logged_successfully = true
+log_wrong_password = true
+log_commands = true
+log_quit = true
+```
+:::

--- a/docs/pt/config/rcon.md
+++ b/docs/pt/config/rcon.md
@@ -1,95 +1,122 @@
 # RCON
-RCON is a protocol that allows you to remotely manage the server from a different device. Pumpkin has full support for RCON.
 
-## Configuring RCON
+RCON é um protocolo que permite gerenciar o servidor remotamente a partir de outro dispositivo. Pumpkin oferece suporte completo para RCON.
 
-#### `enabled`: Boolean
+## Configurando o RCON
+
+#### `enabled`: Booleano
 
 :::code-group
+
 ```toml [features.toml] {2}
 [rcon]
 enabled = true
 ```
+
 :::
 
 #### `address`: String
-The address and port that RCON should listen to.
+
+O endereço e a porta que o RCON deve escutar.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [rcon]
 enabled = true
 address = "0.0.0.0:25575"
 ```
+
 :::
 
 #### `password`: String
-The password to use for RCON authentication.
+
+A senha a ser usada para autenticação RCON.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [rcon]
 enabled = true
-password = "[your safe password here]"
+password = "[sua senha segura aqui]"
 ```
+
 :::
 
-#### `max_connections`: Integer
-The max number of RCON connections allowed at a single time. Set this to 0 to disable the limit.
+#### `max_connections`: Inteiro
+
+O número máximo de conexões RCON permitidas ao mesmo tempo. Defina como 0 para desabilitar o limite.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [rcon]
 enabled = true
 max_connections = 5
 ```
+
 :::
 
-### Logging
-#### `log_logged_successfully`: Boolean
-Whether successful logins should be logged to console or not.
+### Registro de Logs
+
+#### `log_logged_successfully`: Booleano
+
+Se os logins bem-sucedidos devem ser registrados no console ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [rcon.logging]
 log_logged_successfully = true
 ```
+
 :::
 
-#### `log_wrong_password`: Boolean
-Whether wrong password attempts should be logged to console or not.
+#### `log_wrong_password`: Booleano
+
+Se as tentativas de senha incorreta devem ser registradas no console ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [rcon.logging]
-log_logged_successfully = true
+log_wrong_password = true
 ```
+
 :::
 
-#### `log_commands`: Boolean
-Whether to log commands ran from RCON to console or not.
+#### `log_commands`: Booleano
+
+Se os comandos executados via RCON devem ser registrados no console ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [rcon.logging]
 log_commands = true
 ```
+
 :::
 
-#### `log_quit`: Boolean
-Whether RCON client quit should be logged or not.
+#### `log_quit`: Booleano
+
+Se a saída do cliente RCON deve ser registrada ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [rcon.logging]
 log_quit = true
 ```
+
 :::
 
-## Default Config
-By default, RCON is disabled.
+## Configuração Padrão
+
+Por padrão, o RCON está desabilitado.
 
 :::code-group
+
 ```toml [features.toml]
 [rcon]
 enabled = false
@@ -103,4 +130,5 @@ log_wrong_password = true
 log_commands = true
 log_quit = true
 ```
+
 :::

--- a/docs/pt/config/resource-pack.md
+++ b/docs/pt/config/resource-pack.md
@@ -1,91 +1,113 @@
-# Resource Pack
-Servers can send resource packs to clients in order to change the appearance of the game on the client. Pumpkin allows you to fully configure the resource pack.
+# Pacote de Recursos
 
-> [!TIP]
-> Minify your resource pack using [PackSquash](https://packsquash.aylas.org/)! This can help clients download the resource pack faster.
+Servidores podem enviar pacotes de recursos para os clientes a fim de alterar a aparência do jogo no cliente. Pumpkin permite que você configure completamente o pacote de recursos.
 
-## Configuring Resource Pack
+> [!TIP] DICA
+> Minifique seu pacote de recursos usando o [PackSquash](https://packsquash.aylas.org/)! Isso pode ajudar os clientes a baixar o pacote de recursos mais rápido.
 
-#### `enabled`: Boolean
-Whether a resource pack is enabled or not.
+## Configurando o Pacote de Recursos
+
+#### `enabled`: Booleano
+
+Se o pacote de recursos está habilitado ou não.
 
 :::code-group
+
 ```toml [features.toml] {2}
 [resource_pack]
 enabled = true
 ```
+
 :::
 
 #### `resource_pack_url`: String
-The direct download URL to the resource pack. 
 
-> [!TIP]
-> You can host the resource pack for free at [MCPacks](https://mc-packs.net/).
+A URL direta de download do pacote de recursos.
+
+> [!TIP] DICA
+> Você pode hospedar o pacote de recursos gratuitamente no [MCPacks](https://mc-packs.net/).
 
 :::code-group
+
 ```toml [features.toml] {3}
 [resource_pack]
 enabled = true
-resource_pack_url = "[your download URL here]"
+resource_pack_url = "[sua URL de download aqui]"
 ```
+
 :::
 
 #### `resource_pack_sha1`: String
-The SHA1 hash of the resource pack.
 
-> [!IMPORTANT]
-> Although not required to specify, you should specify this field because the client will otherwise redownload the resource pack every time they join the server, even if there are no changes to the resource pack.
+O hash SHA1 do pacote de recursos.
 
-> [!WARNING]
-> Make sure to update this field if the resource pack is modified.
+> [!IMPORTANT] IMPORTANTE
+> Embora não seja necessário especificar, você deve informar este campo porque, caso contrário, o cliente fará o download do pacote de recursos toda vez que entrar no servidor, mesmo que não haja alterações no pacote.
 
-::: details How do I get the SHA1 hash of my resource pack?
+> [!WARNING] AVISO
+> Certifique-se de atualizar este campo se o pacote de recursos for modificado.
+
+::: detalhes Como obter o hash SHA1 do meu pacote de recursos?
 ::: code-group
+
 ```powershell [Windows (PowerShell)]
-Get-FileHash [file] SHA1
+Get-FileHash [arquivo] SHA1
 ```
+
 ```shell [Mac OS]
-shasum -a 1 [file]
+shasum -a 1 [arquivo]
 ```
+
 ```shell [Linux]
-sha1sum [file]
+sha1sum [arquivo]
 ```
+
 :::
 
 :::code-group
+
 ```toml [features.toml] {3}
 [resource_pack]
 enabled = true
-resource_pack_sha1 = "[your hash here]"
+resource_pack_sha1 = "[seu hash aqui]"
 ```
+
 :::
 
 #### `prompt_message`: String
-The message to show to the user when prompted to download the resource pack.
+
+A mensagem a ser exibida para o usuário quando for solicitado o download do pacote de recursos.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [resource_pack]
 enabled = true
-prompt_message = "[your message here]"
+prompt_message = "[sua mensagem aqui]"
 ```
+
 :::
 
-#### `force`: Boolean
-Whether to force the client to download the resource pack or not. If the client declines the download, they will be kicked from the server.
+#### `force`: Booleano
+
+Se deve forçar o cliente a baixar o pacote de recursos ou não. Se o cliente recusar o download, ele será expulso do servidor.
 
 :::code-group
+
 ```toml [features.toml] {3}
 [resource_pack]
 enabled = true
 force = false
 ```
+
 :::
 
-## Default Config
-By default, no resource pack is sent to clients.
+## Configuração Padrão
+
+Por padrão, nenhum pacote de recursos é enviado para os clientes.
 
 :::code-group
+
 ```toml [features.toml]
 [resource_pack]
 enabled = false
@@ -94,4 +116,5 @@ resource_pack_sha1 = ""
 prompt_message = ""
 force = false
 ```
+
 :::

--- a/docs/pt/config/resource-pack.md
+++ b/docs/pt/config/resource-pack.md
@@ -1,0 +1,97 @@
+# Resource Pack
+Servers can send resource packs to clients in order to change the appearance of the game on the client. Pumpkin allows you to fully configure the resource pack.
+
+> [!TIP]
+> Minify your resource pack using [PackSquash](https://packsquash.aylas.org/)! This can help clients download the resource pack faster.
+
+## Configuring Resource Pack
+
+#### `enabled`: Boolean
+Whether a resource pack is enabled or not.
+
+:::code-group
+```toml [features.toml] {2}
+[resource_pack]
+enabled = true
+```
+:::
+
+#### `resource_pack_url`: String
+The direct download URL to the resource pack. 
+
+> [!TIP]
+> You can host the resource pack for free at [MCPacks](https://mc-packs.net/).
+
+:::code-group
+```toml [features.toml] {3}
+[resource_pack]
+enabled = true
+resource_pack_url = "[your download URL here]"
+```
+:::
+
+#### `resource_pack_sha1`: String
+The SHA1 hash of the resource pack.
+
+> [!IMPORTANT]
+> Although not required to specify, you should specify this field because the client will otherwise redownload the resource pack every time they join the server, even if there are no changes to the resource pack.
+
+> [!WARNING]
+> Make sure to update this field if the resource pack is modified.
+
+::: details How do I get the SHA1 hash of my resource pack?
+::: code-group
+```powershell [Windows (PowerShell)]
+Get-FileHash [file] SHA1
+```
+```shell [Mac OS]
+shasum -a 1 [file]
+```
+```shell [Linux]
+sha1sum [file]
+```
+:::
+
+:::code-group
+```toml [features.toml] {3}
+[resource_pack]
+enabled = true
+resource_pack_sha1 = "[your hash here]"
+```
+:::
+
+#### `prompt_message`: String
+The message to show to the user when prompted to download the resource pack.
+
+:::code-group
+```toml [features.toml] {3}
+[resource_pack]
+enabled = true
+prompt_message = "[your message here]"
+```
+:::
+
+#### `force`: Boolean
+Whether to force the client to download the resource pack or not. If the client declines the download, they will be kicked from the server.
+
+:::code-group
+```toml [features.toml] {3}
+[resource_pack]
+enabled = true
+force = false
+```
+:::
+
+## Default Config
+By default, no resource pack is sent to clients.
+
+:::code-group
+```toml [features.toml]
+[resource_pack]
+enabled = false
+resource_pack_url = ""
+resource_pack_sha1 = ""
+prompt_message = ""
+force = false
+```
+:::

--- a/docs/pt/developer/contributing.md
+++ b/docs/pt/developer/contributing.md
@@ -1,63 +1,73 @@
-### Contributing to Pumpkin
-We appreciate your interest in contributing to Pumpkin! This document outlines the guidelines for submitting bug reports, feature suggestions, and code changes.
+### Contribuindo para o Pumpkin
 
-### Getting Started
-The easiest way to get started is by asking for help in [our Discord server](https://discord.gg/wT8XjrjKkf).
+Agradecemos o seu interesse em contribuir para o Pumpkin! Este documento descreve as diretrizes para o envio de relatórios de bugs, sugestões de funcionalidades e alterações de código.
 
-### How to Contribute
-There are several ways you can contribute to Pumpkin:
+### Começando
 
-#### Reporting Bugs
-  If you encounter a bug, please search for existing issues on the issue tracker first.
+A maneira mais fácil de começar é pedindo ajuda em [nosso servidor do Discord](https://discord.gg/wT8XjrjKkf).
 
-  If you can't find a duplicate issue, open a new one.
+### Como Contribuir
 
-  Follow the template and provide a clear description of the bug, including steps to reproduce it if possible.
-  Screenshots, logs, or code snippets can also be helpful.
+Existem várias maneiras de você contribuir para o Pumpkin:
 
-#### Suggesting Features
-  Do you have an idea on how Pumpkin can be improved? Share your thoughts by opening an issue on the issue tracker.
+#### Reportando Bugs
 
-  Describe the proposed feature in detail, including its benefits and potential implementation considerations.
+Se você encontrar um bug, por favor, procure por problemas existentes no rastreador de problemas primeiro.
 
-#### Contributing Code
-  To get started with contributing code to Pumpkin, fork the repository on GitHub
+Se não encontrar um problema duplicado, abra um novo.
 
-1. First, create a GitHub account if you don't already have one
- 
-2. Go to Pumpkin's official [GitHub Organization](https://github.com/Pumpkin-MC) and press fork
+Siga o modelo e forneça uma descrição clara do bug, incluindo os passos para reproduzi-lo, se possível.
+Capturas de tela, logs ou trechos de código também podem ser úteis.
 
-> Creating a fork means you now have your own copy of the Pumpkin source code (this does not mean you own the copyright).
+#### Sugerindo Funcionalidades
 
-  Now that you have a copy that you can edit, you will need a few tools.
+Tem uma ideia de como o Pumpkin pode ser melhorado? Compartilhe seus pensamentos abrindo um problema no rastreador de problemas.
 
-3. Install [git](https://git-scm.com/downloads) for your operating system
+Descreva a funcionalidade proposta em detalhes, incluindo seus benefícios e considerações sobre a implementação.
 
-- To get started with git, visit [Getting started with Git](https://docs.github.com/en/get-started/getting-started-with-git)
+#### Contribuindo com Código
 
-- Optional: If you want a graphical tool to interact with GitHub, install [GitHub-Desktop](https://desktop.github.com/download/)
+Para começar a contribuir com código para o Pumpkin, faça um fork do repositório no GitHub
 
-> GitHub Desktop may be easier if you are not used to the command line, but it is not for everyone
+1. Primeiro, crie uma conta no GitHub, caso ainda não tenha uma.
 
-- To get started with GitHub Desktop, visit [Getting started with GitHub Desktop](https://docs.github.com/en/desktop/overview/getting-started-with-github-desktop)
+2. Vá até a [Organização oficial do Pumpkin no GitHub](https://github.com/Pumpkin-MC) e clique em "fork".
 
-- If you are wanting to contribute code, install Rust at [rust-lang.org](https://www.rust-lang.org/).
+> Criar um fork significa que você agora tem uma cópia do código-fonte do Pumpkin (isso não significa que você detém os direitos autorais).
 
-- If you are wanting to contribute to documentation, install [NodeJS](https://nodejs.org/en)
+Agora que você tem uma cópia que pode editar, você precisará de algumas ferramentas.
 
-### Decompiling Minecraft's code
-When working at Pumpkin, we heavily rely on the official Minecraft client and utilize existing server logic. We often refer to Minecraft's official code.
-The easiest way to decompile Minecraft is by using Fabric Yarn. Make sure you have Gradle installed before running the following commands:
+3. Instale o [git](https://git-scm.com/downloads) para o seu sistema operacional.
+
+-   Para começar com o git, visite [Começando com Git](https://docs.github.com/en/get-started/getting-started-with-git).
+
+-   Opcional: Se você quiser uma ferramenta gráfica para interagir com o GitHub, instale o [GitHub-Desktop](https://desktop.github.com/download/).
+
+> O GitHub Desktop pode ser mais fácil se você não estiver acostumado com a linha de comando, mas não é para todo mundo.
+
+-   Para começar com o GitHub Desktop, visite [Começando com o GitHub Desktop](https://docs.github.com/en/desktop/overview/getting-started-with-github-desktop).
+
+-   Se você quiser contribuir com código, instale o Rust em [rust-lang.org](https://www.rust-lang.org/).
+
+-   Se você deseja contribuir para a documentação, instale o [NodeJS](https://nodejs.org/en).
+
+### Decompilando o código do Minecraft
+
+Ao trabalhar no Pumpkin, nós dependemos muito do cliente oficial do Minecraft e utilizamos a lógica existente do servidor. Frequentemente, nos referimos ao código oficial do Minecraft.
+A maneira mais fácil de decompilar o Minecraft é utilizando o Fabric Yarn. Certifique-se de ter o Gradle instalado antes de executar os seguintes comandos:
+
 ```
 git clone https://github.com/FabricMC/yarn.git
 cd yarn
 ./gradlew decompileVineflower
 ```
-After decompiling, you can find the source code located in `build/namedSrc`.
 
-### Additional Information
-We encourage you to comment on existing issues and pull requests to share your thoughts and provide feedback.
+Após a decompilação, você pode encontrar o código-fonte localizado em `build/namedSrc`.
 
-Feel free to ask questions in the issue tracker or reach out to the project maintainers if you need assistance.
+### Informações Adicionais
 
-Before submitting a large contribution, consider opening an issue or discussion, or talk with us on our Discord to discuss your approach.
+Incentivamos você a comentar sobre problemas e pull requests existentes para compartilhar suas ideias e fornecer feedback.
+
+Fique à vontade para fazer perguntas no rastreador de problemas ou entrar em contato com os mantenedores do projeto caso precise de ajuda.
+
+Antes de enviar uma grande contribuição, considere abrir um problema ou discussão, ou conversar conosco no nosso Discord para discutir sua abordagem.

--- a/docs/pt/developer/contributing.md
+++ b/docs/pt/developer/contributing.md
@@ -1,0 +1,63 @@
+### Contributing to Pumpkin
+We appreciate your interest in contributing to Pumpkin! This document outlines the guidelines for submitting bug reports, feature suggestions, and code changes.
+
+### Getting Started
+The easiest way to get started is by asking for help in [our Discord server](https://discord.gg/wT8XjrjKkf).
+
+### How to Contribute
+There are several ways you can contribute to Pumpkin:
+
+#### Reporting Bugs
+  If you encounter a bug, please search for existing issues on the issue tracker first.
+
+  If you can't find a duplicate issue, open a new one.
+
+  Follow the template and provide a clear description of the bug, including steps to reproduce it if possible.
+  Screenshots, logs, or code snippets can also be helpful.
+
+#### Suggesting Features
+  Do you have an idea on how Pumpkin can be improved? Share your thoughts by opening an issue on the issue tracker.
+
+  Describe the proposed feature in detail, including its benefits and potential implementation considerations.
+
+#### Contributing Code
+  To get started with contributing code to Pumpkin, fork the repository on GitHub
+
+1. First, create a GitHub account if you don't already have one
+ 
+2. Go to Pumpkin's official [GitHub Organization](https://github.com/Pumpkin-MC) and press fork
+
+> Creating a fork means you now have your own copy of the Pumpkin source code (this does not mean you own the copyright).
+
+  Now that you have a copy that you can edit, you will need a few tools.
+
+3. Install [git](https://git-scm.com/downloads) for your operating system
+
+- To get started with git, visit [Getting started with Git](https://docs.github.com/en/get-started/getting-started-with-git)
+
+- Optional: If you want a graphical tool to interact with GitHub, install [GitHub-Desktop](https://desktop.github.com/download/)
+
+> GitHub Desktop may be easier if you are not used to the command line, but it is not for everyone
+
+- To get started with GitHub Desktop, visit [Getting started with GitHub Desktop](https://docs.github.com/en/desktop/overview/getting-started-with-github-desktop)
+
+- If you are wanting to contribute code, install Rust at [rust-lang.org](https://www.rust-lang.org/).
+
+- If you are wanting to contribute to documentation, install [NodeJS](https://nodejs.org/en)
+
+### Decompiling Minecraft's code
+When working at Pumpkin, we heavily rely on the official Minecraft client and utilize existing server logic. We often refer to Minecraft's official code.
+The easiest way to decompile Minecraft is by using Fabric Yarn. Make sure you have Gradle installed before running the following commands:
+```
+git clone https://github.com/FabricMC/yarn.git
+cd yarn
+./gradlew decompileVineflower
+```
+After decompiling, you can find the source code located in `build/namedSrc`.
+
+### Additional Information
+We encourage you to comment on existing issues and pull requests to share your thoughts and provide feedback.
+
+Feel free to ask questions in the issue tracker or reach out to the project maintainers if you need assistance.
+
+Before submitting a large contribution, consider opening an issue or discussion, or talk with us on our Discord to discuss your approach.

--- a/docs/pt/developer/introduction.md
+++ b/docs/pt/developer/introduction.md
@@ -1,8 +1,9 @@
-### Introduction
+### Introdução
 
-Welcome to the Pumpkin Documentation!
+Bem-vindo à Documentação do Pumpkin!
 
-Whether you're an internal Pumpkin developer or working on a Pumpkin plugin, this documentation is your resource for everything Pumpkin.
+Seja você um desenvolvedor interno do Pumpkin ou esteja trabalhando em um plugin do Pumpkin, esta documentação é o seu recurso para tudo relacionado ao Pumpkin.
 
-#### Plugin Development
-For a better documentation structure, plugin development docs have been moved to a [separate category](/plugin-dev/introduction).
+#### Desenvolvimento de Plugins
+
+Para uma estrutura de documentação mais organizada, a documentação sobre desenvolvimento de plugins foi movida para uma [categoria separada](/plugin-dev/introduction).

--- a/docs/pt/developer/introduction.md
+++ b/docs/pt/developer/introduction.md
@@ -1,0 +1,8 @@
+### Introduction
+
+Welcome to the Pumpkin Documentation!
+
+Whether you're an internal Pumpkin developer or working on a Pumpkin plugin, this documentation is your resource for everything Pumpkin.
+
+#### Plugin Development
+For a better documentation structure, plugin development docs have been moved to a [separate category](/plugin-dev/introduction).

--- a/docs/pt/developer/mobile.md
+++ b/docs/pt/developer/mobile.md
@@ -1,0 +1,69 @@
+# Pumpking Development on Mobile
+
+If you are a mobile user and want to edit the source code, you can do this!
+(This page was written on Android using Helix.)
+
+First of all, we need a terminal app.
+We recommend [Termux](https://github.com/termux/termux-app/releases) because it's stable and open source.
+Download the needed apk file for your device's architecture and install Termux.
+
+After this, you need to run some commands. We use Helix for its simplicity.
+```bash
+  pkg update && pkg upgrade
+  pkg install build-essential git rust rust-analyzer taplo helix helix-grammar nodejs
+```
+
+If you want to contribute, you need to install the GitHub software.
+```bash
+  pkg install gh
+```
+
+We also recommend installing the fish shell because it's more friendly than bash.
+```bash
+  pkg install fish
+  chsh -s fish
+```
+
+Now that you've installed basic tools, we need to do some setup.
+If you want to contribute, you need log into GitHub.
+```bash
+  gh auth login
+```
+
+Also setup git: change the editor to vim, edit your credentials, etc.
+
+After this, you need to clone the Pumpkin repo. (Before this, you can create a project directory with `mkdir proj`; it's useful)
+```bash
+  git clone https://github.com/Pumpkin-MC/Pumpkin.git
+```
+
+If you want to contribute, you need to fork our repo and change `Pumpkin-MC` to your username on GitHub.
+
+Setup's all done now! Enjoy :)
+
+# FAQ
+
+## How to use the text editor?
+Type `hx <path>`.
+
+## How to navigate through the project?
+You can use `ls`, `cd`, and other programs.
+You can also use `hx <dir>` to browse your directory on startup.
+
+## How can I type in the editor?
+Press `i` if you are in normal mode.
+
+## HOW EXIT FROM EDITOR????
+Press esc, then type `:q!` if you don't want to save, or `:wq` if you do want to save.
+
+## Where can I learn how to use this editor?
+Run `hx --tutor` or go their official website.
+
+## Why not use VS Code?
+1) VS Code is hard to set up, and it works with limited functionality on web.
+2) rust-analyzer doesn't work on it. Maybe an emulator can help with this, but that slows down code compilation.
+3) With VS Code, it's highly desirable to have a mouse, while in Helix you only need a keyboard.
+4) VS Code is laggy on some devices.
+
+## Why is it so hard to type?
+Buy a cheap bluetooth keyboard and see how much easier it becomes.

--- a/docs/pt/developer/mobile.md
+++ b/docs/pt/developer/mobile.md
@@ -1,69 +1,81 @@
-# Pumpking Development on Mobile
+# Desenvolvimento do Pumpkin no Mobile
 
-If you are a mobile user and want to edit the source code, you can do this!
-(This page was written on Android using Helix.)
+Se você é um usuário móvel e deseja editar o código-fonte, você consegue fazer isso!  
+(Esta página foi escrita no Android usando o Helix.)
 
-First of all, we need a terminal app.
-We recommend [Termux](https://github.com/termux/termux-app/releases) because it's stable and open source.
-Download the needed apk file for your device's architecture and install Termux.
+Primeiro de tudo, precisamos de um aplicativo de terminal.  
+Recomendamos o [Termux](https://github.com/termux/termux-app/releases) porque é estável e open source.  
+Baixe o arquivo apk necessário para a arquitetura do seu dispositivo e instale o Termux.
 
-After this, you need to run some commands. We use Helix for its simplicity.
+Após isso, você precisará rodar alguns comandos. Usamos o Helix pela sua simplicidade.
+
 ```bash
   pkg update && pkg upgrade
   pkg install build-essential git rust rust-analyzer taplo helix helix-grammar nodejs
 ```
 
-If you want to contribute, you need to install the GitHub software.
+Se você quiser contribuir, precisará instalar o software do GitHub.
+
 ```bash
   pkg install gh
 ```
 
-We also recommend installing the fish shell because it's more friendly than bash.
+Também recomendamos instalar o fish shell porque ele é mais amigável do que o bash.
+
 ```bash
   pkg install fish
   chsh -s fish
 ```
 
-Now that you've installed basic tools, we need to do some setup.
-If you want to contribute, you need log into GitHub.
+Agora que você instalou as ferramentas básicas, precisamos fazer algumas configurações.  
+Se você quiser contribuir, precisará fazer login no GitHub.
+
 ```bash
   gh auth login
 ```
 
-Also setup git: change the editor to vim, edit your credentials, etc.
+Também configure o git: altere o editor para o vim, edite suas credenciais, etc.
 
-After this, you need to clone the Pumpkin repo. (Before this, you can create a project directory with `mkdir proj`; it's useful)
+Após isso, você precisa clonar o repositório do Pumpkin. (Antes disso, você pode criar um diretório de projeto com `mkdir proj`; é útil)
+
 ```bash
   git clone https://github.com/Pumpkin-MC/Pumpkin.git
 ```
 
-If you want to contribute, you need to fork our repo and change `Pumpkin-MC` to your username on GitHub.
+Se você quiser contribuir, precisa fazer um fork do nosso repositório e trocar `Pumpkin-MC` pelo seu nome de usuário no GitHub.
 
-Setup's all done now! Enjoy :)
+A configuração está toda feita agora! Aproveite :)
 
 # FAQ
 
-## How to use the text editor?
-Type `hx <path>`.
+## Como usar o editor de texto?
 
-## How to navigate through the project?
-You can use `ls`, `cd`, and other programs.
-You can also use `hx <dir>` to browse your directory on startup.
+Digite `hx <caminho>`.
 
-## How can I type in the editor?
-Press `i` if you are in normal mode.
+## Como navegar pelo projeto?
 
-## HOW EXIT FROM EDITOR????
-Press esc, then type `:q!` if you don't want to save, or `:wq` if you do want to save.
+Você pode usar `ls`, `cd` e outros programas.  
+Também pode usar `hx <diretório>` para navegar pelo seu diretório ao iniciar.
 
-## Where can I learn how to use this editor?
-Run `hx --tutor` or go their official website.
+## Como posso digitar no editor?
 
-## Why not use VS Code?
-1) VS Code is hard to set up, and it works with limited functionality on web.
-2) rust-analyzer doesn't work on it. Maybe an emulator can help with this, but that slows down code compilation.
-3) With VS Code, it's highly desirable to have a mouse, while in Helix you only need a keyboard.
-4) VS Code is laggy on some devices.
+Pressione `i` se você estiver no modo normal.
 
-## Why is it so hard to type?
-Buy a cheap bluetooth keyboard and see how much easier it becomes.
+## COMO SAIR DO EDITOR????
+
+Pressione `esc` e depois digite `:q!` se não quiser salvar, ou `:wq` se quiser salvar.
+
+## Onde posso aprender a usar esse editor?
+
+Execute `hx --tutor` ou acesse o site oficial deles.
+
+## Por que não usar o VS Code?
+
+1. O VS Code é difícil de configurar e funciona com funcionalidades limitadas na versão web.
+2. O rust-analyzer não funciona nele. Talvez um emulador ajude com isso, mas isso pode retardar a compilação do código.
+3. Com o VS Code, é altamente desejável ter um mouse, enquanto no Helix você só precisa de um teclado.
+4. O VS Code é lento em alguns dispositivos.
+
+## Por que é tão difícil digitar?
+
+Compre um teclado bluetooth barato e veja como fica mais fácil.

--- a/docs/pt/developer/networking/authentication.md
+++ b/docs/pt/developer/networking/authentication.md
@@ -1,0 +1,53 @@
+## Authentication
+### Why authentication
+Offline accounts, that is, accounts generated from a player's username without contacting an authorization or authentication server, can have any nickname chosen. This, without additional plugins, means that players can impersonate other players, including those with operator permissions.
+
+### Offline server
+By default, `online_mode` is enabled in the configuration. This enables authentication, disabling offline accounts. If you want to allow offline accounts, you can disable `online_mode` in `configuration.toml`.
+
+### How Yggdrasil Auth works
+1. The client gets an authentication token and UUID from the launcher.
+2. The client, during loading, fetches data from the authorization/authentication server using the authentication token, such as various signing keys and the list of blocked servers.
+3. The client, when joining the server, sends a join request to the authorization/authentication servers. Mojang servers can deny this request if the account is banned.
+4. The client sends its identification to the server in a packet.
+5. The server, based on this identification, sends a `hasJoined` request to the authorization/authentication servers. If it succeeds, it obtains the player information, such as the skin.
+
+### Custom Authentication Server
+
+Pumpkin supports custom authentication servers. You can replace the authentication URL in `features.toml`.
+
+#### How Pumpkin Authentication Works
+
+1. **GET Request:** Pumpkin sends a GET request to the specified authentication URL.
+2. **Status Code 200:** If the authentication is successful, the server responds with a status code of 200.
+3. **Parse JSON Game Profile:** Pumpkin parses the JSON game profile returned in the response.
+
+#### Game Profile
+
+```rust
+struct GameProfile {
+    id: UUID,
+    name: String,
+    properties: Vec<Property>,
+    profile_actions: Option<Vec<ProfileAction>>, // Optional, only present when actions are applied
+}
+```
+
+##### Property
+
+```rust
+struct Property {
+    name: String,
+    value: String, // Base64 encoded
+    signature: Option<String>, // Optional, Base64 encoded
+}
+```
+
+##### Profile Action
+
+```rust
+enum ProfileAction {
+    FORCED_NAME_CHANGE,
+    USING_BANNED_SKIN,
+}
+```

--- a/docs/pt/developer/networking/authentication.md
+++ b/docs/pt/developer/networking/authentication.md
@@ -1,49 +1,53 @@
-## Authentication
-### Why authentication
-Offline accounts, that is, accounts generated from a player's username without contacting an authorization or authentication server, can have any nickname chosen. This, without additional plugins, means that players can impersonate other players, including those with operator permissions.
+## Autenticação
 
-### Offline server
-By default, `online_mode` is enabled in the configuration. This enables authentication, disabling offline accounts. If you want to allow offline accounts, you can disable `online_mode` in `configuration.toml`.
+### Por que a autenticação é necessária
 
-### How Yggdrasil Auth works
-1. The client gets an authentication token and UUID from the launcher.
-2. The client, during loading, fetches data from the authorization/authentication server using the authentication token, such as various signing keys and the list of blocked servers.
-3. The client, when joining the server, sends a join request to the authorization/authentication servers. Mojang servers can deny this request if the account is banned.
-4. The client sends its identification to the server in a packet.
-5. The server, based on this identification, sends a `hasJoined` request to the authorization/authentication servers. If it succeeds, it obtains the player information, such as the skin.
+Contas offline, ou seja, contas geradas a partir do nome de usuário de um jogador sem entrar em contato com um servidor de autorização ou autenticação, podem ter qualquer nickname escolhido. Isso, sem plugins adicionais, significa que jogadores podem se passar por outros jogadores, incluindo aqueles com permissões de operador.
 
-### Custom Authentication Server
+### Servidor Offline
 
-Pumpkin supports custom authentication servers. You can replace the authentication URL in `features.toml`.
+Por padrão, `online_mode` está ativado na configuração. Isso habilita a autenticação, desabilitando contas offline. Se você deseja permitir contas offline, pode desabilitar `online_mode` no arquivo `configuration.toml`.
 
-#### How Pumpkin Authentication Works
+### Como funciona a autenticação Yggdrasil
 
-1. **GET Request:** Pumpkin sends a GET request to the specified authentication URL.
-2. **Status Code 200:** If the authentication is successful, the server responds with a status code of 200.
-3. **Parse JSON Game Profile:** Pumpkin parses the JSON game profile returned in the response.
+1. O cliente obtém um token de autenticação e UUID do launcher.
+2. O cliente, durante o carregamento, obtém dados do servidor de autorização/autenticação usando o token de autenticação, como várias chaves de assinatura e a lista de servidores bloqueados.
+3. O cliente, ao entrar no servidor, envia uma solicitação de entrada para os servidores de autorização/autenticação. Os servidores Mojang podem negar essa solicitação se a conta estiver banida.
+4. O cliente envia sua identificação para o servidor em um pacote.
+5. O servidor, com base nessa identificação, envia uma solicitação `hasJoined` para os servidores de autorização/autenticação. Se for bem-sucedido, ele obtém as informações do jogador, como a skin.
 
-#### Game Profile
+### Servidor de Autenticação Personalizado
+
+Pumpkin suporta servidores de autenticação personalizados. Você pode substituir a URL de autenticação no arquivo `features.toml`.
+
+#### Como funciona a autenticação no Pumpkin
+
+1. **Requisição GET:** Pumpkin envia uma requisição GET para a URL de autenticação especificada.
+2. **Código de status 200:** Se a autenticação for bem-sucedida, o servidor responde com o código de status 200.
+3. **Parse do Perfil de Jogo em JSON:** O Pumpkin analisa o perfil de jogo em JSON retornado na resposta.
+
+#### Perfil de Jogo
 
 ```rust
 struct GameProfile {
     id: UUID,
     name: String,
     properties: Vec<Property>,
-    profile_actions: Option<Vec<ProfileAction>>, // Optional, only present when actions are applied
+    profile_actions: Option<Vec<ProfileAction>>, // Opcional, presente apenas quando ações são aplicadas
 }
 ```
 
-##### Property
+##### Propriedade
 
 ```rust
 struct Property {
     name: String,
-    value: String, // Base64 encoded
-    signature: Option<String>, // Optional, Base64 encoded
+    value: String, // Codificado em Base64
+    signature: Option<String>, // Opcional, codificado em Base64
 }
 ```
 
-##### Profile Action
+##### Ação de Perfil
 
 ```rust
 enum ProfileAction {

--- a/docs/pt/developer/networking/networking.md
+++ b/docs/pt/developer/networking/networking.md
@@ -1,0 +1,242 @@
+### Networking
+
+Most of the networking code in Pumpkin can be found in the [pumpkin-protocol](https://github.com/Pumpkin-MC/Pumpkin/tree/master/pumpkin-protocol) crate.
+
+Serverbound: Client→Server
+
+Clientbound: Server→Client
+
+### Structure
+
+Packets in the Pumpkin protocol are organized by functionality and state.
+
+`server`: Contains definitions for serverbound packets.
+
+`client`: Contains definitions for clientbound packets.
+
+### States
+
+**Handshake**: Always the first packet being sent from the client. This also determines the next state, usually to indicate if the player wants to perform a status request, join the server, or wants to be transferred.
+
+**Status**: Indicates the client wants to see a status response (MOTD).
+
+**Login**: The login sequence. Indicates the client wants to join the server.
+
+**Config**: A sequence of configuration packets is mostly sent from the server to the client (features, resource pack, server links, etc.).
+
+**Play**: The final state, which indicates the player is now ready to join, is also used to handle all other gameplay packets.
+
+### Minecraft Protocol
+
+You can find all Minecraft Java packets at https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol. There you also can see which [state](#States) they are in.
+You can also can see all the information the packets have, which we can either read or write depending on whether they are serverbound or clientbound.
+
+### Adding a Packet
+
+1. Adding a packet is easy. First, derive:
+
+```rust
+// For clientbound packets:
+#[derive(Serialize)]
+
+// For serverbound packets:
+#[derive(Deserialize)]
+```
+
+2. Next, you have to make it known that your struct represents a packet. This automatically gets the packet ID from the JSON packets file.
+
+```rust
+// For clientbound packets:
+#[client_packet("play:disconnect")]
+
+// For serverbound packets:
+#[server_packet("login:move_player_pos")]
+```
+
+3. Now you can create the `struct`.
+
+> [!IMPORTANT]
+> Please start the packet name with "C" or "S" for "Clientbound" or "Serverbound".
+> Also, if it's a packet that can be sent in multiple [states](#States), please add the state to the name. For example, there are 3 different disconnect packets.
+>
+> -   `CLoginDisconnect`
+> -   `CConfigDisconnect`
+> -   `CPlayDisconnect`
+
+Create fields within your packet structure to represent the data that will be sent.
+
+> [!IMPORTANT]
+> Use descriptive field names and appropriate data types.
+
+Examples:
+
+```rust
+pub struct CPlayDisconnect {
+    reason: TextComponent,
+    // more fields...
+}
+
+pub struct SPlayerPosition {
+    pub x: f64,
+    pub feet_y: f64,
+    pub z: f64,
+    pub ground: bool,
+}
+```
+
+4. (Clientbound packets only) `impl` a `new` function so we can actually create them by putting in the values.
+
+```rust
+impl CPlayDisconnect {
+    pub fn new(reason: TextComponent) -> Self {
+        Self { reason }
+    }
+}
+```
+
+5. In the end, everything should come together.
+
+```rust
+#[derive(Serialize)]
+#[client_packet("play:disconnect")]
+pub struct CPlayDisconnect {
+    reason: TextComponent,
+}
+
+impl CPlayDisconnect {
+    pub fn new(reason: TextComponent) -> Self {
+        Self { reason }
+    }
+}
+
+#[derive(Deserialize)]
+#[server_packet("login:move_player_pos")]
+pub struct SPlayerPosition {
+    pub x: f64,
+    pub feet_y: f64,
+    pub z: f64,
+    pub ground: bool,
+}
+```
+
+6. You can also serialize/deserialize the packet manually, which can be useful if the packet is more complex.
+
+```diff
+-#[derive(Serialize)]
+
++ impl ClientPacket for CPlayDisconnect {
++    fn write(&self, bytebuf: &mut BytesMut) {
++       bytebuf.put_slice(&self.reason.encode());
++    }
+
+-#[derive(Deserialize)]
+
++ impl ServerPacket for SPlayerPosition {
++    fn read(bytebuf: &mut Bytes) -> Result<Self, ReadingError> {
++       Ok(Self {
++           x: bytebuf.try_get_f64()?,
++           feet_y: bytebuf.try_get_f64()?,
++           z: bytebuf.try_get_f64()?,
++           ground: bytebuf.try_get_bool()?,
++       })
++    }
+```
+
+7. You can now send the clientbound packet (see [Sending Packets](#sending-packets)) or listen for the serverbound packet (see [Receiving Packets](#receiving-packets)).
+
+### Client
+
+Pumpkin categorizes `Client`s and `Player`s separately. Everything that is not in the play state is a simple `Client`. Here are the differences:
+
+**Client**
+
+-   Can only be the states: Status, Login, Transfer, Config
+-   Is not a living entity
+-   Has small resource consumption
+
+**Player**
+
+-   Can only be in the Play state
+-   Is a living entity in a world
+-   Has more data and consumes more resources
+
+#### Sending Packets
+
+Example:
+
+```rust
+// Works only in the Status state
+client.send_packet(&CStatusResponse::new("{ description: "A Description"}"));
+```
+
+#### Receiving Packets
+
+For `Client`s:
+`src/client/mod.rs`
+
+```diff
+// Put the packet into the right state
+ fn handle_mystate_packet(
+  &self,
+    server: &Arc<Server>,
+    packet: &mut RawPacket,
+) -> Result<(), ReadingError> {
+    let bytebuf = &mut packet.bytebuf;
+    match packet.id.0 {
+        SStatusRequest::PACKET_ID => {
+                self.handle_status_request(server, SStatusRequest::read(bytebuf)?)
+                    .await;
+            }
++            MyPacket::PACKET_ID => {
++                self.handle_my_packet(MyPacket::read(bytebuf)?)
++                    .await;
+            }
+            _ => {
+            log::error!(
+                "Failed to handle packet id {} while in ... state",
+                packet.id.0
+            );
+            }
+    };
+    Ok(())
+}
+```
+
+For `Player`s:
+`src/entity/player.rs`
+
+```diff
+// Players only have the Play state
+ fn handle_play_packet(
+  &self,
+    server: &Arc<Server>,
+    packet: &mut RawPacket,
+) -> Result<(), ReadingError> {
+    let bytebuf = &mut packet.bytebuf;
+    match packet.id.0 {
+        SChatMessage::PACKET_ID => {
+            self.handle_chat_message(SChatMessage::read(bytebuf)?).await;
+        }
+       MyPacket::PACKET_ID => {
++           self.handle_mypacket(server, MyPacket::read(bytebuf)?).await;
+        }
+        _ => {
+            log::error!(
+                "Failed to handle packet id {} while in ... state",
+                packet.id.0
+            );
+        }
+    };
+    Ok(())
+}
+```
+
+### Compression
+
+Minecraft packets **can** use ZLib compression for decoding/encoding. There is usually a threshold set when compression is applied; this most often affects chunk packets.
+
+### Porting
+
+To port to a new minecraft version, you can compare differences in the protocol on the [minecraft.wiki Protocol reference](https://minecraft.wiki/w/Java_Edition_protocol).
+
+Also, change the `CURRENT_MC_PROTOCOL` in `src/lib.rs`.

--- a/docs/pt/developer/networking/rcon.md
+++ b/docs/pt/developer/networking/rcon.md
@@ -1,64 +1,64 @@
 ### RCON
 
-### What is RCON
+### O que é RCON
 
-RCON (Remote Console) is a protocol designed by Valve to allow administrators to control and manage game servers remotely. It provides a way to execute commands on a server from a different location, such as a phone or a separate computer.
+RCON (Console Remoto) é um protocolo criado pela Valve para permitir que administradores controlem e gerenciem servidores de jogos remotamente. Ele oferece uma maneira de executar comandos em um servidor de um local diferente, como um celular ou um computador separado.
 
-### Why RCON
+### Por que usar RCON
 
-- **Convenience:** Manage your server from anywhere with an internet connection.
-- **Flexibility:** Execute commands without needing to be physically present at the server's location.
-- **Efficiency:** Automate tasks and streamline server management.
+-   **Conveniência:** Gerencie seu servidor de qualquer lugar com uma conexão à internet.
+-   **Flexibilidade:** Execute comandos sem precisar estar fisicamente presente no local do servidor.
+-   **Eficiência:** Automatize tarefas e torne o gerenciamento do servidor mais ágil.
 
 ### SSH vs RCON
 
 **SSH**
 
-- Offers strong encryption to protect data transmitted between the client and server.
-- Primarily designed for secure remote login and execution of commands on a remote machine.
-- Commonly used for managing Linux/Unix systems, configuring networks, and running scripts.
-- Provides a shell-like environment, allowing you to execute various commands and interact with the remote system.
+-   Oferece forte criptografia para proteger os dados transmitidos entre o cliente e o servidor.
+-   Principalmente projetado para login remoto seguro e execução de comandos em uma máquina remota.
+-   Comumente usado para gerenciar sistemas Linux/Unix, configurar redes e executar scripts.
+-   Fornece um ambiente de shell, permitindo que você execute diversos comandos e interaja com o sistema remoto.
 
 **RCON**
 
-- Specifically designed for remote administration of game servers, allowing you to control and manage the server's settings and operations.
-- Typically less secure than SSH, as it often relies on plain text passwords.
-- Primarily used by game server administrators to manage game servers.
-- Has a limited set of game-specific commands.
+-   Especificamente projetado para administração remota de servidores de jogos, permitindo que você controle e gerencie as configurações e operações do servidor.
+-   Geralmente menos seguro que o SSH, pois muitas vezes depende de senhas em texto simples.
+-   Principalmente utilizado por administradores de servidores de jogos para gerenciar servidores de jogos.
+-   Tem um conjunto limitado de comandos, específicos do jogo.
 
-### Packets
+### Pacotes
 
-RCON is a very simple protocol with a few packets. Here's how an RCON packet looks:
+RCON é um protocolo muito simples com poucos pacotes. Veja como um pacote RCON se parece:
 
-| Field | Description                                     |
-| ----- | ----------------------------------------------- |
-| ID    | Used to indicate whether authentication failed or succeeded |
-| Type  | Identifies the packet type                      |
-| Body  | A message (String), e.g., a command or a password |
+| Campo | Descrição                                                   |
+| ----- | ----------------------------------------------------------- |
+| ID    | Usado para indicar se a autenticação falhou ou teve sucesso |
+| Tipo  | Identifica o tipo de pacote                                 |
+| Corpo | Uma mensagem (String), por exemplo, um comando ou uma senha |
 
-#### Serverbound Packets <sub><sub>(Client→Server)</sub></sub>
+#### Pacotes Serverbound <sub><sub>(Cliente→Servidor)</sub></sub>
 
-| Type | Packet      |
+| Tipo | Pacote      |
 | ---- | ----------- |
 | 2    | Auth        |
 | 3    | ExecCommand |
 
-#### Clientbound Packets <sub><sub>(Server→Client)</sub></sub>
+#### Pacotes Clientbound <sub><sub>(Servidor→Cliente)</sub></sub>
 
-| Type | Packet       |
+| Tipo | Pacote       |
 | ---- | ------------ |
 | 2    | AuthResponse |
 | 0    | Output       |
 
-### How RCON Works
+### Como o RCON Funciona
 
-1. **Authentication:**
+1. **Autenticação:**
 
-   - The RCON client sends an authentication packet with the desired password.
-   - The server verifies the password and responds with an authentication response packet.
-   - If successful, the response packet includes the same ID as the one sent by the client. If unsuccessful, the ID is -1.
+    - O cliente RCON envia um pacote de autenticação com a senha desejada.
+    - O servidor verifica a senha e responde com um pacote de resposta de autenticação.
+    - Se bem-sucedido, o pacote de resposta inclui o mesmo ID enviado pelo cliente. Se não for bem-sucedido, o ID é -1.
 
-2. **Command Execution:**
+2. **Execução de Comandos:**
 
-   - The authenticated client can now send command execution packets, with each packet containing the command to be executed.
-   - The server processes the command and sends back an output packet containing the result or any error messages.
+    - O cliente autenticado pode agora enviar pacotes de execução de comandos, com cada pacote contendo o comando a ser executado.
+    - O servidor processa o comando e envia de volta um pacote de saída contendo o resultado ou qualquer mensagem de erro.

--- a/docs/pt/developer/networking/rcon.md
+++ b/docs/pt/developer/networking/rcon.md
@@ -1,0 +1,64 @@
+### RCON
+
+### What is RCON
+
+RCON (Remote Console) is a protocol designed by Valve to allow administrators to control and manage game servers remotely. It provides a way to execute commands on a server from a different location, such as a phone or a separate computer.
+
+### Why RCON
+
+- **Convenience:** Manage your server from anywhere with an internet connection.
+- **Flexibility:** Execute commands without needing to be physically present at the server's location.
+- **Efficiency:** Automate tasks and streamline server management.
+
+### SSH vs RCON
+
+**SSH**
+
+- Offers strong encryption to protect data transmitted between the client and server.
+- Primarily designed for secure remote login and execution of commands on a remote machine.
+- Commonly used for managing Linux/Unix systems, configuring networks, and running scripts.
+- Provides a shell-like environment, allowing you to execute various commands and interact with the remote system.
+
+**RCON**
+
+- Specifically designed for remote administration of game servers, allowing you to control and manage the server's settings and operations.
+- Typically less secure than SSH, as it often relies on plain text passwords.
+- Primarily used by game server administrators to manage game servers.
+- Has a limited set of game-specific commands.
+
+### Packets
+
+RCON is a very simple protocol with a few packets. Here's how an RCON packet looks:
+
+| Field | Description                                     |
+| ----- | ----------------------------------------------- |
+| ID    | Used to indicate whether authentication failed or succeeded |
+| Type  | Identifies the packet type                      |
+| Body  | A message (String), e.g., a command or a password |
+
+#### Serverbound Packets <sub><sub>(Client→Server)</sub></sub>
+
+| Type | Packet      |
+| ---- | ----------- |
+| 2    | Auth        |
+| 3    | ExecCommand |
+
+#### Clientbound Packets <sub><sub>(Server→Client)</sub></sub>
+
+| Type | Packet       |
+| ---- | ------------ |
+| 2    | AuthResponse |
+| 0    | Output       |
+
+### How RCON Works
+
+1. **Authentication:**
+
+   - The RCON client sends an authentication packet with the desired password.
+   - The server verifies the password and responds with an authentication response packet.
+   - If successful, the response packet includes the same ID as the one sent by the client. If unsuccessful, the ID is -1.
+
+2. **Command Execution:**
+
+   - The authenticated client can now send command execution packets, with each packet containing the command to be executed.
+   - The server processes the command and sends back an output packet containing the result or any error messages.

--- a/docs/pt/developer/world.md
+++ b/docs/pt/developer/world.md
@@ -1,0 +1,83 @@
+### World Formats
+
+#### Region File Format
+
+Minecraft Beta 1.3 to Release 1.2 used a Minecraft format known as the "Region file format".
+
+The files stored in this format are `.mcr` files, each storing a group of 32x32 chunks called a region.
+
+More details can be found on the [Minecraft Wiki](https://minecraft.wiki/w/Region_file_format).
+
+#### Anvil File Format
+
+Replacing the Region File Format after Minecraft Release 1.2, this is the file format used to store modern Vanilla Minecraft: Java Edition worlds.
+
+The files stored in this format are `.mca` files. While using the same region logic, there were a number of changes. The notable changes include an increase
+to a 256 height limit, then to 320, as well as a higher number of block IDs.
+
+More details can be found on the [Minecraft Wiki](https://minecraft.wiki/w/Anvil_file_format).
+
+#### Linear File Format
+
+There is a more modern file format known as the Linear region file format. It saves on disk space and uses the zstd library instead of zlib. This is beneficial as zlib is extremely old and
+outdated.
+
+The files stored in this format are `.linear` files, and it saves about 50% of disk space in the Overworld and the Nether, and saves 95% in the End.
+
+More details can be found at the GitHub page for [LinearRegionFileFormatTools](https://github.com/xymb-endcrystalme/LinearRegionFileFormatTools).
+
+#### Slime File Format
+
+Developed by Hypixel to fix many of the pitfalls of the Anvil file format, Slime also replaces zlib and saves space compared to Anvil. It saves the entire world in a single save
+file, and allows that file to be loaded into multiple instances.
+
+The files stored in this format are `.slime` files.
+
+More details can be found on the GitHub page for [Slime World Manager](https://github.com/cijaaimee/Slime-World-Manager#:~:text=Slime%20World%20Manager%20is%20a,worlds%20faster%20and%20save%20space.), as well as on [Dev Blog #5](https://hypixel.net/threads/dev-blog-5-storing-your-skyblock-island.2190753/) for Hypixel.
+
+#### Schematic File Format
+
+Unlike the other file formats listed, the Schematic File Format is not used for storing Minecraft worlds, but instead used within 3rd party programs such as MCEdit, WorldEdit, and Schematica.
+
+The files stored in this format are `.schematic` files, and are stored in the NBT format.
+
+More details can be found on the [Minecraft Wiki](https://minecraft.wiki/w/Schematic_file_format)
+
+### World Generation
+
+When the server is starting up, it checks if there is a save present, also known as the "world".
+
+Pumpkin then calls for world generation:
+
+#### Save Present
+
+`AnvilChunkReader` is called to process the region files for the given save
+
+-   As stated above, region files store 32x32 chunks
+    > Each region file is named corresponding to coordinates of where it is in the world
+
+> r.{}.{}.mca
+
+-   The location table is read from the save file, representing the chunk coordinates
+-   The timestamp table is read from the save file, representing the last time the chunk was modified
+
+#### No Save Present
+
+The world seed is set to "0". In the future it will be set to the value in the "basic" configuration.
+
+`PlainsGenerator` is called, as so far `Plains` is the only biome that has been implemented.
+
+-   `PerlinTerrainGenerator` is called to set chunk height
+-   Stone height is set 5 below chunk height
+-   Dirt height is set to 2 below chunk height
+-   Grass blocks appear at the top of dirt
+-   Bedrock is set at y = -64
+-   Flowers and short grass are scattered about randomly
+
+`SuperflatGenerator` is also available, but is not currently callable.
+
+-   Bedrock is set at y = -64
+-   Dirt is set two blocks up
+-   Grass blocks are set one more block up
+
+Blocks are able to be placed and broken, but changes are not able to be saved in any world format. Anvil worlds are currently read only.

--- a/docs/pt/developer/world.md
+++ b/docs/pt/developer/world.md
@@ -1,83 +1,80 @@
-### World Formats
+### Formatos de Mundo
 
-#### Region File Format
+#### Formato de Arquivo de Região
 
-Minecraft Beta 1.3 to Release 1.2 used a Minecraft format known as the "Region file format".
+Do Minecraft Beta 1.3 até o Release 1.2, era utilizado um formato de Minecraft conhecido como "Formato de Arquivo de Região".
 
-The files stored in this format are `.mcr` files, each storing a group of 32x32 chunks called a region.
+Os arquivos armazenados nesse formato são arquivos `.mcr`, cada um armazenando um grupo de 32x32 chunks, chamado de região.
 
-More details can be found on the [Minecraft Wiki](https://minecraft.wiki/w/Region_file_format).
+Mais detalhes podem ser encontrados na [Minecraft Wiki](https://minecraft.wiki/w/Region_file_format).
 
-#### Anvil File Format
+#### Formato de Arquivo Anvil
 
-Replacing the Region File Format after Minecraft Release 1.2, this is the file format used to store modern Vanilla Minecraft: Java Edition worlds.
+Substituindo o Formato de Arquivo de Região após o Minecraft Release 1.2, este é o formato de arquivo usado para armazenar mundos modernos do Minecraft: Java Edition.
 
-The files stored in this format are `.mca` files. While using the same region logic, there were a number of changes. The notable changes include an increase
-to a 256 height limit, then to 320, as well as a higher number of block IDs.
+Os arquivos armazenados nesse formato são arquivos `.mca`. Embora utilize a mesma lógica de regiões, houve várias mudanças. As mudanças notáveis incluem o aumento do limite de altura para 256, depois para 320, assim como um maior número de IDs de blocos.
 
-More details can be found on the [Minecraft Wiki](https://minecraft.wiki/w/Anvil_file_format).
+Mais detalhes podem ser encontrados na [Minecraft Wiki](https://minecraft.wiki/w/Anvil_file_format).
 
-#### Linear File Format
+#### Formato de Arquivo Linear
 
-There is a more modern file format known as the Linear region file format. It saves on disk space and uses the zstd library instead of zlib. This is beneficial as zlib is extremely old and
-outdated.
+Existe um formato de arquivo mais moderno conhecido como Formato de Arquivo de Região Linear. Ele economiza espaço em disco e usa a biblioteca zstd em vez de zlib. Isso é benéfico, pois o zlib é extremamente antigo e desatualizado.
 
-The files stored in this format are `.linear` files, and it saves about 50% of disk space in the Overworld and the Nether, and saves 95% in the End.
+Os arquivos armazenados nesse formato são arquivos `.linear`, e eles economizam cerca de 50% de espaço em disco no Overworld e no Nether, e 95% no End.
 
-More details can be found at the GitHub page for [LinearRegionFileFormatTools](https://github.com/xymb-endcrystalme/LinearRegionFileFormatTools).
+Mais detalhes podem ser encontrados na página do GitHub para [LinearRegionFileFormatTools](https://github.com/xymb-endcrystalme/LinearRegionFileFormatTools).
 
-#### Slime File Format
+#### Formato de Arquivo Slime
 
-Developed by Hypixel to fix many of the pitfalls of the Anvil file format, Slime also replaces zlib and saves space compared to Anvil. It saves the entire world in a single save
-file, and allows that file to be loaded into multiple instances.
+Desenvolvido pela Hypixel para corrigir muitos dos problemas do formato de arquivo Anvil, o Slime também substitui o zlib e economiza espaço em comparação com o Anvil. Ele salva o mundo inteiro em um único arquivo de salvamento e permite que esse arquivo seja carregado em várias instâncias.
 
-The files stored in this format are `.slime` files.
+Os arquivos armazenados nesse formato são arquivos `.slime`.
 
-More details can be found on the GitHub page for [Slime World Manager](https://github.com/cijaaimee/Slime-World-Manager#:~:text=Slime%20World%20Manager%20is%20a,worlds%20faster%20and%20save%20space.), as well as on [Dev Blog #5](https://hypixel.net/threads/dev-blog-5-storing-your-skyblock-island.2190753/) for Hypixel.
+Mais detalhes podem ser encontrados na página do GitHub para [Slime World Manager](https://github.com/cijaaimee/Slime-World-Manager#:~:text=Slime%20World%20Manager%20is%20a,worlds%20faster%20and%20save%20space.), assim como no [Dev Blog #5](https://hypixel.net/threads/dev-blog-5-storing-your-skyblock-island.2190753/) da Hypixel.
 
-#### Schematic File Format
+#### Formato de Arquivo Schematic
 
-Unlike the other file formats listed, the Schematic File Format is not used for storing Minecraft worlds, but instead used within 3rd party programs such as MCEdit, WorldEdit, and Schematica.
+Diferentemente dos outros formatos de arquivo listados, o Formato de Arquivo Schematic não é usado para armazenar mundos do Minecraft, mas sim dentro de programas de terceiros, como MCEdit, WorldEdit e Schematica.
 
-The files stored in this format are `.schematic` files, and are stored in the NBT format.
+Os arquivos armazenados nesse formato são arquivos `.schematic`, e são armazenados no formato NBT.
 
-More details can be found on the [Minecraft Wiki](https://minecraft.wiki/w/Schematic_file_format)
+Mais detalhes podem ser encontrados na [Minecraft Wiki](https://minecraft.wiki/w/Schematic_file_format).
 
-### World Generation
+### Geração de Mundo
 
-When the server is starting up, it checks if there is a save present, also known as the "world".
+Quando o servidor está iniciando, ele verifica se há um salvamento presente, também conhecido como "mundo".
 
-Pumpkin then calls for world generation:
+Pumpkin então chama a geração do mundo:
 
-#### Save Present
+#### Salvamento Presente
 
-`AnvilChunkReader` is called to process the region files for the given save
+`AnvilChunkReader` é chamado para processar os arquivos de região para o salvamento dado.
 
--   As stated above, region files store 32x32 chunks
-    > Each region file is named corresponding to coordinates of where it is in the world
+-   Como mencionado acima, os arquivos de região armazenam chunks de 32x32.
+    > Cada arquivo de região é nomeado de acordo com as coordenadas de onde ele está no mundo.
 
 > r.{}.{}.mca
 
--   The location table is read from the save file, representing the chunk coordinates
--   The timestamp table is read from the save file, representing the last time the chunk was modified
+-   A tabela de localização é lida a partir do arquivo de salvamento, representando as coordenadas do chunk.
+-   A tabela de timestamp é lida a partir do arquivo de salvamento, representando a última vez que o chunk foi modificado.
 
-#### No Save Present
+#### Sem Salvamento Presente
 
-The world seed is set to "0". In the future it will be set to the value in the "basic" configuration.
+A semente do mundo é definida como "0". No futuro, ela será definida para o valor na configuração "básica".
 
-`PlainsGenerator` is called, as so far `Plains` is the only biome that has been implemented.
+`PlainsGenerator` é chamado, já que até agora `Plains` é o único bioma implementado.
 
--   `PerlinTerrainGenerator` is called to set chunk height
--   Stone height is set 5 below chunk height
--   Dirt height is set to 2 below chunk height
--   Grass blocks appear at the top of dirt
--   Bedrock is set at y = -64
--   Flowers and short grass are scattered about randomly
+-   `PerlinTerrainGenerator` é chamado para definir a altura do chunk.
+-   A altura da pedra é definida 5 blocos abaixo da altura do chunk.
+-   A altura da terra é definida 2 blocos abaixo da altura do chunk.
+-   Blocos de grama aparecem no topo da terra.
+-   Bedrock é definido em y = -64.
+-   Flores e grama curta são espalhadas aleatoriamente.
 
-`SuperflatGenerator` is also available, but is not currently callable.
+`SuperflatGenerator` também está disponível, mas não é atualmente chamável.
 
--   Bedrock is set at y = -64
--   Dirt is set two blocks up
--   Grass blocks are set one more block up
+-   Bedrocks é definido em y = -64.
+-   A terra é definida dois blocos para cima.
+-   Os blocos de grama são definidos um bloco a mais para cima.
 
-Blocks are able to be placed and broken, but changes are not able to be saved in any world format. Anvil worlds are currently read only.
+Os blocos podem ser colocados e quebrados, mas as mudanças não podem ser salvas em nenhum formato de mundo. Mundos do formato Anvil são atualmente apenas leitura.

--- a/docs/pt/index.md
+++ b/docs/pt/index.md
@@ -1,0 +1,34 @@
+---
+# https://vitepress.dev/reference/default-theme-home-page
+layout: home
+
+hero:
+    name: "Pumpkin"
+    text: "Servidor de Minecraft"
+    tagline: Possibilitando a todos hospedar servidores de Minecraft rápidos e eficientes.
+    image:
+        src: /assets/icon.png
+        alt: Pumpkin
+    actions:
+        - theme: brand
+          text: Primeiros Passos
+          link: /pt/about/quick-start
+        - theme: alt
+          text: Configuração
+          link: /pt/config/introduction
+        - theme: alt
+          text: Desenvolvedores
+          link: /pt/developer/introduction
+
+features:
+    # Need to add the svg here instead of using src because then it won't have the box around it
+    - icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="-20 -20 146 146"><g transform="translate(53 53)"><path stroke="#000" stroke-linejoin="round" d="M-8.5-14.5h13c8 0 8 8 0 8h-13Zm-31 37h40v-11h-9v-8h10c11 0 5 19 14 19h25v-19h-6v2c0 8-9 7-10 2s-5-9-6-9c15-8 6-24-6-24h-47v11h10v26h-15Z"/><g mask="url(#a)"><circle r="43" fill="none" stroke="#000" stroke-width="9"/><path id="b" stroke="#000" stroke-linejoin="round" stroke-width="3" d="m46 3 5-3-5-3z"/><use href="#b" transform="rotate(11.3)"/><use href="#b" transform="rotate(22.5)"/><use href="#b" transform="rotate(33.8)"/><use href="#b" transform="rotate(45)"/><use href="#b" transform="rotate(56.3)"/><use href="#b" transform="rotate(67.5)"/><use href="#b" transform="rotate(78.8)"/><use href="#b" transform="rotate(90)"/><use href="#b" transform="rotate(101.3)"/><use href="#b" transform="rotate(112.5)"/><use href="#b" transform="rotate(123.8)"/><use href="#b" transform="rotate(135)"/><use href="#b" transform="rotate(146.3)"/><use href="#b" transform="rotate(157.5)"/><use href="#b" transform="rotate(168.8)"/><use href="#b" transform="rotate(180)"/><use href="#b" transform="rotate(191.3)"/><use href="#b" transform="rotate(202.5)"/><use href="#b" transform="rotate(213.8)"/><use href="#b" transform="rotate(225)"/><use href="#b" transform="rotate(236.3)"/><use href="#b" transform="rotate(247.5)"/><use href="#b" transform="rotate(258.8)"/><use href="#b" transform="rotate(270)"/><use href="#b" transform="rotate(281.3)"/><use href="#b" transform="rotate(292.5)"/><use href="#b" transform="rotate(303.8)"/><use href="#b" transform="rotate(315)"/><use href="#b" transform="rotate(326.3)"/><use href="#b" transform="rotate(337.5)"/><use href="#b" transform="rotate(348.8)"/><path id="c" stroke="#000" stroke-linejoin="round" stroke-width="6" d="m-7-42 7 7 7-7z"/><use href="#c" transform="rotate(72)"/><use href="#c" transform="rotate(144)"/><use href="#c" transform="rotate(216)"/><use href="#c" transform="rotate(288)"/></g><mask id="a"><path fill="#fff" d="M-60-60H60V60H-60z"/><circle id="d" cy="-40" r="3"/><use href="#d" transform="rotate(72)"/><use href="#d" transform="rotate(144)"/><use href="#d" transform="rotate(216)"/><use href="#d" transform="rotate(288)"/></mask></g></svg>
+      title: Escrito em Rust
+      details: Pumpkin é escrito 100% em Rust, garantindo segurança de memória e desempenho incomparável.
+    - icon: 📋
+      title: Funcionalidade completa
+      details: Com todos os recursos vanila suportados, você não terá problemas.
+    - icon: ⚙️
+      title: Flexível
+      details: Altamente configurável, com a capacidade de desabilitar recursos desnecessários.
+---

--- a/docs/pt/plugin-dev/introduction.md
+++ b/docs/pt/plugin-dev/introduction.md
@@ -1,0 +1,10 @@
+# Pumpkin Plugin Development
+::: warning
+The Pumpkin Plugin API is still in a very early stage of development and may change at any time.
+If you run into any issues please reach out on [our Discord server](https://discord.gg/aaNuD6rFEe).
+:::
+
+Pumpkin Plugins integrate with the server software on a very deep level allowing for many things that would not be possible on other server software.
+
+The Pumpkin Plugin API takes inspiration from the Spigot/Bukkit plugin API in many places, so if you have previous experience with these and have experience with Rust development, you should have a pretty easy time writing plugins for Pumpkin. :smile:
+

--- a/docs/pt/plugin-dev/introduction.md
+++ b/docs/pt/plugin-dev/introduction.md
@@ -1,10 +1,10 @@
-# Pumpkin Plugin Development
-::: warning
-The Pumpkin Plugin API is still in a very early stage of development and may change at any time.
-If you run into any issues please reach out on [our Discord server](https://discord.gg/aaNuD6rFEe).
+# Desenvolvimento de Plugins Pumpkin
+
+::: warning ATENÇÃO
+A API de Plugins Pumpkin ainda está em um estágio inicial de desenvolvimento e pode mudar a qualquer momento.
+Se você encontrar algum problema, por favor, entre em contato em [nosso servidor no Discord](https://discord.gg/aaNuD6rFEe).
 :::
 
-Pumpkin Plugins integrate with the server software on a very deep level allowing for many things that would not be possible on other server software.
+Os Plugins Pumpkin se integram ao software do servidor de maneira muito profunda, permitindo muitas coisas que não seriam possíveis em outros softwares de servidor.
 
-The Pumpkin Plugin API takes inspiration from the Spigot/Bukkit plugin API in many places, so if you have previous experience with these and have experience with Rust development, you should have a pretty easy time writing plugins for Pumpkin. :smile:
-
+A API de Plugins Pumpkin se inspira na API de plugins do Spigot/Bukkit em diversos aspectos, então, se você tem experiência prévia com os mesmos e possui experiência com desenvolvimento em Rust, você terá uma experiência relativamente fácil ao escrever plugins para o Pumpkin. :smile:

--- a/docs/pt/plugin-dev/plugin-template/basic-logic.md
+++ b/docs/pt/plugin-dev/plugin-template/basic-logic.md
@@ -1,8 +1,11 @@
-# Writing the basic logic
-## Plugin base
-Even in a basic plugin, there is a lot going on under the hood, so to greatly simplify plugin development we will use the `pumpkin-api-macros` crate to create a basic empty plugin.
+# Escrevendo a Lógica Básica
+
+## Base do Plugin
+
+Mesmo em um plugin básico, há muita coisa acontecendo nos bastidores, então, para simplificar bastante o desenvolvimento de plugins, usaremos o crate `pumpkin-api-macros` para criar um plugin básico vazio.
 
 :::code-group
+
 ```rs:line-numbers [lib.rs]
 use pumpkin_api_macros::plugin_impl;
 
@@ -21,57 +24,66 @@ impl Default for MyPlugin {
     }
 }
 ```
+
 :::
 
-This will create an empty plugin and implement all the necessary methods for it to be loaded by Pumpkin.
+Isso criará um plugin vazio e implementará todos os métodos necessários para que ele seja carregado pelo Pumpkin.
 
-We can now try to compile our plugin for the first time. To do so, run this command in your project folder:
+Agora podemos tentar compilar nosso plugin pela primeira vez. Para isso, execute o seguinte comando na pasta do seu projeto:
+
 ```bash
 cargo build --release
 ```
-::: tip NOTICE
-If you are using Windows, you **must** use the `--release` flag, or you will run into issues. If you are on another platform, you don't have to use it if you want to save on compile time.
-:::
-The initial compilation will take a bit, but don't worry, later compilations will be faster.
 
-If all went well, you should be left with a message like this:
+::: tip AVISO
+Se você estiver usando o Windows, você **tem** que usar a flag `--release`, caso contrário, terá problemas. Se você estiver em outra plataforma, não precisa usá-la caso queira economizar tempo de compilação.
+:::
+A compilação inicial levará um pouco de tempo, mas não se preocupe, as compilações seguintes serão mais rápidas.
+
+Se tudo correr bem, você deverá ver uma mensagem como esta:
+
 ```log
 ╰─ cargo build --release
    Compiling hello-pumpkin v0.1.0 (/home/vypal/Dokumenty/GitHub/hello-pumpkin)
     Finished `release` profile [optimized] target(s) in 0.68s
 ```
 
-Now you can go to the `./target/release` folder (or `./target/debug` if you didn't use `--release`) and locate your plugin binary.
+Agora você pode ir para a pasta `./target/release` (ou `./target/debug` se não usou `--release`) e localizar o binário do seu plugin.
 
-Depending on your operating system, the file will have one of three possible names:
-- For Windows: `hello-pumpkin.dll`
-- For MacOS: `libhello-pumpkin.dylib`
-- For Linux: `libhello-pumpkin.so`
+Dependendo do seu sistema operacional, o arquivo terá um dos três nomes possíveis:
 
-::: info NOTE
-If you used a different project name in the `Cargo.toml` file, look for a file which contains your project name.
+-   Para Windows: `hello-pumpkin.dll`
+-   Para MacOS: `libhello-pumpkin.dylib`
+-   Para Linux: `libhello-pumpkin.so`
+
+::: info NOTA
+Se você usou um nome de projeto diferente no arquivo `Cargo.toml`, procure o arquivo que contenha o nome do seu projeto.
 :::
 
-You can rename this file to whatever you like, however you must keep the file extension (`.dll`, `.dylib`, or `.so`) the same.
+Você pode renomear este arquivo como quiser, mas deve manter a extensão do arquivo (`.dll`, `.dylib` ou `.so`) a mesma.
 
-## Testing the plugin
-Now that we have our plugin binary, we can go ahead and test it on the Pumpkin server. Installing a plugin is as simple as putting the plugin binary that we just built into the `plugins/` folder of your Pumpkin server!
+## Testando o Plugin
 
-Thanks to the `#[plugin_impl]` macro, the plugin will have its details (like the name, authors, version, and description) built into the binary so that the server can read them. 
+Agora que temos o binário do plugin, podemos testá-lo no servidor Pumpkin. Instalar um plugin é tão simples quanto colocar o binário do plugin que acabamos de construir na pasta `plugins/` do seu servidor Pumpkin!
 
-When you start up the server and run the `/plugins` command, you should see an output like this:
+Graças à macro `#[plugin_impl]`, o plugin terá seus detalhes (como nome, autores, versão e descrição) incorporados ao binário para que o servidor possa lê-los.
+
+Quando você iniciar o servidor e executar o comando `/plugins`, deverá ver uma resposta como esta:
+
 ```
-There is 1 plugin loaded:
+Há 1 plugin carregado:
 hello-pumpkin
 ```
 
-## Basic methods
-The Pumpkin server currently uses two "methods" to tell the plugin about its state. These methods are `on_load` and `on_unload`.
+## Métodos Básicos
 
-These methods don't have to be implemented, but you will usually implement at least the `on_load` method. In this method you get access to a `Context` object which can give the plugin access to information about the server, but also allows the plugin to register command handlers and events.
+O servidor Pumpkin atualmente usa dois "métodos" para informar ao plugin sobre seu estado. Esses métodos são `on_load` e `on_unload`.
 
-To make implementing these methods easier, there is another macro provided by the `pumpkin-api-macros` crate. 
+Esses métodos não precisam ser implementados, mas você normalmente implementará pelo menos o método `on_load`. Nesse método, você tem acesso a um objeto `Context`, que pode fornecer ao plugin acesso a informações sobre o servidor, além de permitir que o plugin registre gerenciadores de comandos e eventos.
+
+Para facilitar a implementação desses métodos, há outra macro fornecida pelo crate `pumpkin-api-macros`.
 :::code-group
+
 ```rs [lib.rs]
 use pumpkin_api_macros::{plugin_impl, plugin_method}; // [!code ++:2]
 use pumpkin::plugin::Context;
@@ -97,40 +109,51 @@ impl Default for MyPlugin {
     }
 }
 ```
+
 :::
 
-::: warning IMPORTANT
-It is important that you define any plugin methods before the `#[plugin_impl]` block.
+::: warning IMPORTANTE
+É importante que você defina qualquer método do plugin antes do bloco `#[plugin_impl]`.
 :::
 
-This method gets a mutable reference to its plugin object (in this case the `MyPlugin` struct) which it can use to initialize any data stored in the plugin's main struct, and a reference to a `Context` object. This object is specifically constructed for this plugin based on the plugin's metadata.
+Este método recebe uma referência mutável ao objeto do plugin (neste caso, a struct `MyPlugin`), que pode ser usada para inicializar quaisquer dados armazenados na struct principal do plugin, e uma referência ao objeto `Context`. Esse objeto é especificamente construído para este plugin com base nos metadados do plugin.
 
-### Methods implemented on the `Context` object:
+### Métodos implementados no objeto `Context`:
+
 ```rs
 fn get_data_folder() -> String
 ```
-Returns the path to the folder dedicated to this plugin, which should be used for persistent data storage
+
+Retorna o caminho para a pasta dedicada a este plugin, que deve ser usada para armazenamento de dados persistentes.
+
 ```rs
 async fn get_player_by_name(player_name: String) -> Option<Arc<Player>>
 ```
-If a player by the name `player_name` is found (has to be currently online), this function will return a reference to them.
+
+Se um jogador com o nome `player_name` for encontrado (ele precisa estar online no momento), esta função retornará uma referência a ele.
+
 ```rs
 async fn register_command(tree: CommandTree, permission: PermissionLvl)
 ```
-Registers a new command handler, with a minimum required permission level.
+
+Registra um novo gerenciador de comandos, com um nível mínimo de permissão exigido.
+
 ```rs
 async fn register_event(handler: Arc<H>, priority: EventPriority, blocking: bool)
 ```
-Registers a new event handler with a set priority and if it is blocking or not.
-By the way, `handler` is `Arc<T>`, which means you can implement a lot of events on one handler, and then register it.
 
-## Basic on-load method
-For now we will only implement a very basic `on_load` method to be able to see that the plugin is running.
+Registra um novo gerenciador de eventos com uma prioridade definida e se é bloqueante ou não.
+Aliás, `handler` é `Arc<T>`, o que significa que você pode implementar vários eventos em um único gerenciador e depois registrá-lo.
 
-Here we will set up the inner Pumpkin logger and set up a "Hello, Pumpkin!" so that we can see our plugin in action.
+## Método Básico `on_load`
 
-Add this to the `on_load` method:
+Por enquanto, vamos implementar apenas um método `on_load` bem básico para conseguirmos ver que o plugin está funcionando.
+
+Aqui vamos configurar o logger interno do Pumpkin e exibir "Hello, Pumpkin!" para que possamos ver nosso plugin em ação.
+
+Adicione isso ao método `on_load`:
 :::code-group
+
 ```rs [lib.rs]
 #[plugin_method]
 async fn on_load(&mut self, server: &Context) -> Result<(), String> {
@@ -141,6 +164,7 @@ async fn on_load(&mut self, server: &Context) -> Result<(), String> {
     Ok(())
 }
 ```
+
 :::
 
-If we build the plugin again and start up the server, you should now see "Hello, Pumpkin!" somewhere in the log.
+Se compilarmos o plugin novamente e iniciarmos o servidor, agora você deverá ver "Hello, Pumpkin!" em algum lugar no log.

--- a/docs/pt/plugin-dev/plugin-template/basic-logic.md
+++ b/docs/pt/plugin-dev/plugin-template/basic-logic.md
@@ -1,0 +1,146 @@
+# Writing the basic logic
+## Plugin base
+Even in a basic plugin, there is a lot going on under the hood, so to greatly simplify plugin development we will use the `pumpkin-api-macros` crate to create a basic empty plugin.
+
+:::code-group
+```rs:line-numbers [lib.rs]
+use pumpkin_api_macros::plugin_impl;
+
+#[plugin_impl]
+pub struct MyPlugin {}
+
+impl MyPlugin {
+    pub fn new() -> Self {
+        MyPlugin {}
+    }
+}
+
+impl Default for MyPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+```
+:::
+
+This will create an empty plugin and implement all the necessary methods for it to be loaded by Pumpkin.
+
+We can now try to compile our plugin for the first time. To do so, run this command in your project folder:
+```bash
+cargo build --release
+```
+::: tip NOTICE
+If you are using Windows, you **must** use the `--release` flag, or you will run into issues. If you are on another platform, you don't have to use it if you want to save on compile time.
+:::
+The initial compilation will take a bit, but don't worry, later compilations will be faster.
+
+If all went well, you should be left with a message like this:
+```log
+╰─ cargo build --release
+   Compiling hello-pumpkin v0.1.0 (/home/vypal/Dokumenty/GitHub/hello-pumpkin)
+    Finished `release` profile [optimized] target(s) in 0.68s
+```
+
+Now you can go to the `./target/release` folder (or `./target/debug` if you didn't use `--release`) and locate your plugin binary.
+
+Depending on your operating system, the file will have one of three possible names:
+- For Windows: `hello-pumpkin.dll`
+- For MacOS: `libhello-pumpkin.dylib`
+- For Linux: `libhello-pumpkin.so`
+
+::: info NOTE
+If you used a different project name in the `Cargo.toml` file, look for a file which contains your project name.
+:::
+
+You can rename this file to whatever you like, however you must keep the file extension (`.dll`, `.dylib`, or `.so`) the same.
+
+## Testing the plugin
+Now that we have our plugin binary, we can go ahead and test it on the Pumpkin server. Installing a plugin is as simple as putting the plugin binary that we just built into the `plugins/` folder of your Pumpkin server!
+
+Thanks to the `#[plugin_impl]` macro, the plugin will have its details (like the name, authors, version, and description) built into the binary so that the server can read them. 
+
+When you start up the server and run the `/plugins` command, you should see an output like this:
+```
+There is 1 plugin loaded:
+hello-pumpkin
+```
+
+## Basic methods
+The Pumpkin server currently uses two "methods" to tell the plugin about its state. These methods are `on_load` and `on_unload`.
+
+These methods don't have to be implemented, but you will usually implement at least the `on_load` method. In this method you get access to a `Context` object which can give the plugin access to information about the server, but also allows the plugin to register command handlers and events.
+
+To make implementing these methods easier, there is another macro provided by the `pumpkin-api-macros` crate. 
+:::code-group
+```rs [lib.rs]
+use pumpkin_api_macros::{plugin_impl, plugin_method}; // [!code ++:2]
+use pumpkin::plugin::Context;
+use pumpkin_api_macros::plugin_impl; // [!code --]
+
+#[plugin_method] // [!code ++:4]
+async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+    Ok(())
+}
+
+#[plugin_impl]
+pub struct MyPlugin {}
+
+impl MyPlugin {
+    pub fn new() -> Self {
+        MyPlugin {}
+    }
+}
+
+impl Default for MyPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+```
+:::
+
+::: warning IMPORTANT
+It is important that you define any plugin methods before the `#[plugin_impl]` block.
+:::
+
+This method gets a mutable reference to its plugin object (in this case the `MyPlugin` struct) which it can use to initialize any data stored in the plugin's main struct, and a reference to a `Context` object. This object is specifically constructed for this plugin based on the plugin's metadata.
+
+### Methods implemented on the `Context` object:
+```rs
+fn get_data_folder() -> String
+```
+Returns the path to the folder dedicated to this plugin, which should be used for persistent data storage
+```rs
+async fn get_player_by_name(player_name: String) -> Option<Arc<Player>>
+```
+If a player by the name `player_name` is found (has to be currently online), this function will return a reference to them.
+```rs
+async fn register_command(tree: CommandTree, permission: PermissionLvl)
+```
+Registers a new command handler, with a minimum required permission level.
+```rs
+async fn register_event(handler: Arc<H>, priority: EventPriority, blocking: bool)
+```
+Registers a new event handler with a set priority and if it is blocking or not.
+By the way, `handler` is `Arc<T>`, which means you can implement a lot of events on one handler, and then register it.
+
+## Basic on-load method
+For now we will only implement a very basic `on_load` method to be able to see that the plugin is running.
+
+Here we will set up the inner Pumpkin logger and set up a "Hello, Pumpkin!" so that we can see our plugin in action.
+
+Add this to the `on_load` method:
+:::code-group
+```rs [lib.rs]
+#[plugin_method]
+async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+    pumpkin::init_log!(); // [!code ++:3]
+
+    log::info!("Hello, Pumpkin!");
+
+    Ok(())
+}
+```
+:::
+
+If we build the plugin again and start up the server, you should now see "Hello, Pumpkin!" somewhere in the log.

--- a/docs/pt/plugin-dev/plugin-template/creating-project.md
+++ b/docs/pt/plugin-dev/plugin-template/creating-project.md
@@ -1,0 +1,71 @@
+# Creating a new project
+Pumpkin plugins use the [Cargo](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html) build system.
+
+The complete code for this plugin can be found as a [template on GitHub](https://github.com/vyPal/Hello-Pumpkin).
+
+## Initializing a new crate
+First we need to create a new project folder. You can do this by running this command in the folder you created:
+```bash
+cargo new <project-name> --lib
+```
+This will create a folder with a couple files in it. The folder structure should look like this:
+```
+├── Cargo.toml
+└── src
+    └── lib.rs
+```
+
+## Configuring the crate
+Since Pumpkin plugins are loaded at runtime as dynamic libraries, we need to tell Cargo to build this crate as one.
+:::code-group
+```toml [Cargo.toml] 
+[package]
+name = "hello-pumpkin"
+version = "0.1.0"
+edition = "2021"
+
+[lib] // [!code ++:3]
+crate-type = ["cdylib"]
+
+[dependencies]
+```
+:::
+
+Next we need to add some basic dependencies. Since Pumpkin is still in early development, the internal crates aren't published to crates.io, so we need to tell Cargo to download the dependencies directly from GitHub.
+:::code-group
+```toml [Cargo.toml]
+[package]
+name = "hello-pumpkin"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+// [!code ++:13]
+# This is the base crate with most high-level type definitions
+pumpkin = { git = "https://github.com/Pumpkin-MC/Pumpkin.git", branch = "master", package = "pumpkin" } 
+# Other utilities used by Pumpkin (e.g. TextComponent, Vectors...)
+pumpkin-util = { git = "https://github.com/Pumpkin-MC/Pumpkin.git", branch = "master", package = "pumpkin-util" }
+# Macros for easier plugin development
+pumpkin-api-macros = { git = "https://github.com/Pumpkin-MC/Pumpkin.git", branch = "master", package = "pumpkin-api-macros" }
+
+# A utility allowing plugins to work asynchronously
+async-trait = "0.1"
+# A rust asynchronous runtime
+tokio = "1.42"
+# Logging
+log = "0.4"
+```
+:::
+
+For improved performance and smaller file sizes, we recommend enabling Link-Time Optimization (LTO).  
+Be aware that this will increase compilation time.
+:::code-group
+```toml [Cargo.toml]
+[profile.release] // [!code ++:2]
+lto = true
+```
+:::
+<small>Enables LTO only for release builds.</small>

--- a/docs/pt/plugin-dev/plugin-template/creating-project.md
+++ b/docs/pt/plugin-dev/plugin-template/creating-project.md
@@ -1,24 +1,31 @@
-# Creating a new project
-Pumpkin plugins use the [Cargo](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html) build system.
+# Criando um Novo Projeto
 
-The complete code for this plugin can be found as a [template on GitHub](https://github.com/vyPal/Hello-Pumpkin).
+Plugins Pumpkin utilizam o sistema de build [Cargo](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html).
 
-## Initializing a new crate
-First we need to create a new project folder. You can do this by running this command in the folder you created:
+O código completo para este plugin pode ser encontrado como um [modelo no GitHub](https://github.com/vyPal/Hello-Pumpkin).
+
+## Inicializando um novo crate
+
+Primeiro, precisamos criar uma nova pasta para o projeto. Você pode fazer isso executando o seguinte comando na pasta que você criou:
+
 ```bash
-cargo new <project-name> --lib
+cargo new <nome-do-projeto> --lib
 ```
-This will create a folder with a couple files in it. The folder structure should look like this:
+
+Isso criará uma pasta com alguns arquivos dentro. A estrutura da pasta deverá ser parecida com esta:
+
 ```
 ├── Cargo.toml
 └── src
     └── lib.rs
 ```
 
-## Configuring the crate
-Since Pumpkin plugins are loaded at runtime as dynamic libraries, we need to tell Cargo to build this crate as one.
+## Configurando o crate
+
+Como os plugins Pumpkin são carregados em tempo de execução como bibliotecas dinâmicas, precisamos dizer ao Cargo para construir esse crate dessa forma.
 :::code-group
-```toml [Cargo.toml] 
+
+```toml [Cargo.toml]
 [package]
 name = "hello-pumpkin"
 version = "0.1.0"
@@ -29,10 +36,12 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ```
+
 :::
 
-Next we need to add some basic dependencies. Since Pumpkin is still in early development, the internal crates aren't published to crates.io, so we need to tell Cargo to download the dependencies directly from GitHub.
+Em seguida, precisamos adicionar algumas dependências básicas. Como o Pumpkin ainda está em desenvolvimento inicial, os crates internos não estão publicados no crates.io, então precisamos dizer ao Cargo para baixar as dependências diretamente do GitHub.
 :::code-group
+
 ```toml [Cargo.toml]
 [package]
 name = "hello-pumpkin"
@@ -44,28 +53,31 @@ crate-type = ["cdylib"]
 
 [dependencies]
 // [!code ++:13]
-# This is the base crate with most high-level type definitions
-pumpkin = { git = "https://github.com/Pumpkin-MC/Pumpkin.git", branch = "master", package = "pumpkin" } 
-# Other utilities used by Pumpkin (e.g. TextComponent, Vectors...)
+# Este é um crate base com a maioria das definições de tipos de alto nível
+pumpkin = { git = "https://github.com/Pumpkin-MC/Pumpkin.git", branch = "master", package = "pumpkin" }
+# Outras utilidades usadas pelo Pumpkin (por exemplo, TextComponent, Vectors...)
 pumpkin-util = { git = "https://github.com/Pumpkin-MC/Pumpkin.git", branch = "master", package = "pumpkin-util" }
-# Macros for easier plugin development
+# Macros para facilitar o desenvolvimento de plugins
 pumpkin-api-macros = { git = "https://github.com/Pumpkin-MC/Pumpkin.git", branch = "master", package = "pumpkin-api-macros" }
 
-# A utility allowing plugins to work asynchronously
+# Uma utilidade permitindo que plugins funcionem de maneira assíncrona
 async-trait = "0.1"
-# A rust asynchronous runtime
+# Um runtime assíncrono em Rust
 tokio = "1.42"
 # Logging
 log = "0.4"
 ```
+
 :::
 
-For improved performance and smaller file sizes, we recommend enabling Link-Time Optimization (LTO).  
-Be aware that this will increase compilation time.
+Para melhorar o desempenho e reduzir o tamanho dos arquivos, recomendamos habilitar a Otimização em Tempo de Link (LTO).  
+Esteja ciente de que isso aumentará o tempo de compilação.
 :::code-group
+
 ```toml [Cargo.toml]
 [profile.release] // [!code ++:2]
 lto = true
 ```
+
 :::
-<small>Enables LTO only for release builds.</small>
+<small>Habilita LTO apenas para builds release.</small>

--- a/docs/pt/plugin-dev/plugin-template/introduction.md
+++ b/docs/pt/plugin-dev/plugin-template/introduction.md
@@ -1,9 +1,11 @@
-# Writing an Example Plugin
-This tutorial will guide you through creating a new plugin.
+# Escrevendo um Plugin de Exemplo
 
-This tutorial expects that you have some experience with Rust and the command line.
+Este tutorial irá guiá-lo na criação de um novo plugin.
 
-Topics described in this tutorial:
-- Modifying the join message
-- Creating a rock-paper-scissors command (coming soon)
-- Saving plugin data in the plugin's directory (coming soon)
+Este tutorial assume que você tem alguma experiência com Rust e linha de comando.
+
+Tópicos descritos neste tutorial:
+
+-   Modificando a mensagem de entrada
+-   Criando um comando de pedra-papel-tesoura (em breve)
+-   Salvando dados do plugin em diretório (em breve)

--- a/docs/pt/plugin-dev/plugin-template/introduction.md
+++ b/docs/pt/plugin-dev/plugin-template/introduction.md
@@ -1,0 +1,9 @@
+# Writing an Example Plugin
+This tutorial will guide you through creating a new plugin.
+
+This tutorial expects that you have some experience with Rust and the command line.
+
+Topics described in this tutorial:
+- Modifying the join message
+- Creating a rock-paper-scissors command (coming soon)
+- Saving plugin data in the plugin's directory (coming soon)

--- a/docs/pt/plugin-dev/plugin-template/join-event.md
+++ b/docs/pt/plugin-dev/plugin-template/join-event.md
@@ -1,0 +1,92 @@
+# Writing a Event Handler
+Event handlers are one of the main functions of plugins. They allow a plugin to tap into the internal workings of the server and alter its behavior to perform some other action. For a simple example, we will implement a handler for the `player_join` event. 
+
+The Pumpkin plugin event system tries to copy the Bukkit/Spigot Event system, so that developers coming from there will have a easier time learning Pumpkin.
+However, Rust has different conceptions and rules, so it's not all like in Bukkit/Spigot.
+Rust doesn't have inheritance; instead it only has composition.
+
+The event system uses traits to dynamically handle some events: `Event`, `Cancellable`, `PlayerEvent` and etc.
+Cancellable can also be an Event, because it's a trait. (TODO: verify this)
+
+## Implementing the Join Event
+Individual event handlers are just structs which implement the `EventHandler<T>` trait (where `T` is a specific event implementation).
+
+### What are blocking events?
+The Pumpkin plugin event system differentiates between two types of events: blocking and non-blocking. Each have their benefits:
+#### Blocking events
+```diff
+Pros:
++ Can modify the event (like editing the join message)
++ Can cancel the event
++ Have a priority system
+Cons:
+- Are executed in sequence
+- Can slow down the server if not implemented well
+```
+#### Non-blocking events
+```diff
+Pros:
++ Are executed concurrently
++ Are executed after all blocking events finish
++ Can still do some modifications (anything that is behind a Mutex or RwLock)
+Cons:
+- Cannot cancel the event
+- Have no priority system
+- Allow for less control over the event
+```
+
+### Writing a handler
+Since our main aim here is to change the welcome message that the player sees when they join a server, we will be choosing the blocking event type with a low priority.
+
+Add this code above the `on_load` method:
+:::code-group
+```rs [lib.rs]
+use async_trait::async_trait; // [!code ++:4]
+use pumpkin_api_macros::with_runtime;
+use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler};
+use pumpkin_util::text::{color::NamedColor, TextComponent};
+
+struct MyJoinHandler; // [!code ++:12]
+
+#[with_runtime(global)]
+#[async_trait]
+impl EventHandler<PlayerJoinEvent> for MyJoinHandler {
+    async fn handle_blocking(&self, event: &mut PlayerJoinEvent) {
+        event.join_message =
+            TextComponent::text(format!("Welcome, {}!", event.player.gameprofile.name))
+                .color_named(NamedColor::Green);
+    }
+}
+```
+:::
+
+**Explanation**:
+- `struct MyJoinHandler;`: The struct for our event handler
+- `#[with_runtime(global)]`: Pumpkin uses the tokio async runtime, which acts in weird ways across the plugin boundary. Even though it is not necessary in this specific example, it is a good practice to wrap all async `impl`s that interact with async code with this macro.
+- `#[async_trait]`: Rust doesn't have full support for traits with async methods. So, we use the `async_trait` crate to allow this.
+- `async fn handle_blocking()`: Since we chose for this event to be blocking, it is necessary to implement the `handle_blocking()` method instead of the `handle()` method.
+
+::: warning IMPORTANT
+It is important that the `#[with_runtime(global)]` macro is **above** the **`#[async_trait]`** macro. If they are in the opposite order, the `#[with_runtime(global)]` macro might not work.
+:::
+
+### Registering the handler
+Now that we have written the event handler, we need to tell the plugin to use it. We can do that by adding a single line into the `on_load` method:
+:::code-group
+```rs [lib.rs]
+use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler, EventPriority}; // [!code ++]
+use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler}; // [!code --]
+
+#[plugin_method]
+async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+    pumpkin::init_log!();
+
+    log::info!("Hello, Pumpkin!");
+
+    server.register_event(Arc::new(MyJoinHandler), EventPriority::Lowest, true).await; // [!code ++]
+
+    Ok(())
+}
+```
+:::
+Now if we build the plugin and join the server, we should see a green "Welcome" message with our username!

--- a/docs/pt/troubleshooting/common_issues.md
+++ b/docs/pt/troubleshooting/common_issues.md
@@ -1,9 +1,9 @@
-### Common Issues
+### Problemas Comuns
 
-1.  ### Failed to verify username
+1.  ### Falha ao verificar nome de usuário
 
-    **Issue:** Some players reported having issues logging into the server, including encountering a "Failed to verify username" error.
+    **Problema:** Alguns jogadores relataram dificuldades ao logar no servidor, incluindo o erro "Falha ao verificar nome de usuário".
 
-    **Cause:** This has to do with authentication, and usually with the `prevent_proxy_connections` setting.
+    **Causa:** Isso está relacionado à autenticação, geralmente com a configuração `prevent_proxy_connections`.
 
-    **Fix:** Disable `prevent_proxy_connections` in `features.toml`
+    **Solução:** Desative a opção `prevent_proxy_connections` em `features.toml`.

--- a/docs/pt/troubleshooting/common_issues.md
+++ b/docs/pt/troubleshooting/common_issues.md
@@ -1,0 +1,9 @@
+### Common Issues
+
+1.  ### Failed to verify username
+
+    **Issue:** Some players reported having issues logging into the server, including encountering a "Failed to verify username" error.
+
+    **Cause:** This has to do with authentication, and usually with the `prevent_proxy_connections` setting.
+
+    **Fix:** Disable `prevent_proxy_connections` in `features.toml`


### PR DESCRIPTION
# Portuguese Localization

Pull request for tracking the progress of Portuguese localization of the documentation, work in progress.

## Repo Tasks:
- [x] Create a new locale file in `docs/.vitepress/` (e.g., `fr.ts` for a French translation).
- [x] Translate the content and update all links with the appropriate language code (refer to the Dutch translation for an example).
- [x] Register the new locale in `docs/.vitepress/config.ts`.
- [x] Duplicate the English documentation folder (`docs/en/`) and rename it to your language's ISO code (e.g., `en` → `pt`).
- [x] Translate all documentation files in the newly created folder.
- [x] Configure the typo check to skip the translation files in `.typos.toml`.

## Documentation Progress:

- [x] Home
- [x] About
  - [x] Introduction
  - [x] Quick Start
  - [x] Benchmarks
- [x] Configuration
  - [x] Introduction
  - [x] Basic
  - [x] Proxy
  - [x] Authentication
  - [x] Compression
  - [x] Resource Pack
  - [x] Commands
  - [x] RCON
  - [x] PVP
  - [x] Logging
  - [x] Query
  - [x] LAN Broadcast
- [x] Developers
  - [x] Contributing
  - [x] Introduction
  - [x] Networking
    - [x] Authentication
    - [x] RCON
  - [x] World
  - [x] Mobile Dev
- [x] Plugin Development
  - [x] Introduction
  - [x] Plugin Template
    - [x] Creating Project
    - [x] Basic Logic
    - [x] Join Event
- [x] Troubleshooting
  - [x] Common Issues
