### PR TITLE
Add Portuguese localization

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,7 @@
 [files]
 extend-exclude = [
     "docs/nl/",
-    "docs/.vitepress/nl.ts"
+    "docs/.vitepress/nl.ts",
+    "docs/pt/",
+    "docs/.vitepress/pt.ts"
 ]

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vitepress";
 import { en } from "./en";
 import { nl } from "./nl";
+import { pt } from "./pt";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -17,6 +18,9 @@ export default defineConfig({
         },
         nl: {
             label: "Dutch", ...nl
+        },
+        pt: {
+            label: "Português", ...pt
         }
     },
 

--- a/docs/.vitepress/pt.ts
+++ b/docs/.vitepress/pt.ts
@@ -1,0 +1,123 @@
+import { defineConfig } from "vitepress";
+
+export const pt = defineConfig({
+    lang: "pt-BR",
+    description: "Um servidor Minecraft de alto desempenho escrito em Rust",
+
+    themeConfig: {
+        // https://vitepress.dev/reference/default-theme-config
+        search: {
+            provider: "local",
+        },
+        nav: [
+            {
+                text: "Documentação",
+                link: "/pt/about/introduction",
+            },
+        ],
+        sidebar: [
+            {
+                text: "Sobre",
+                items: [
+                    { text: "Introdução", link: "/pt/about/introduction" },
+                    { text: "Primeiros Passos", link: "/pt/about/quick-start" },
+                    { text: "Benchmark", link: "/pt/about/benchmarks" },
+                ],
+            },
+            {
+                text: "Configuração",
+                items: [
+                    { text: "Introdução", link: "/pt/config/introduction" },
+                    { text: "Básico", link: "/pt/config/basic" },
+                    { text: "Proxy", link: "/pt/config/proxy" },
+                    { text: "Autenticação", link: "/pt/config/authentication" },
+                    { text: "Compressão", link: "/pt/config/compression" },
+                    { text: "Pacote de Recursos", link: "/pt/config/resource-pack" },
+                    { text: "Comandos", link: "/pt/config/commands" },
+                    { text: "RCON", link: "/pt/config/rcon" },
+                    { text: "PVP", link: "/pt/config/pvp" },
+                    { text: "Log", link: "/pt/config/logging" },
+                    { text: "Query", link: "/pt/config/query" },
+                    { text: "Transmissão LAN", link: "/pt/config/lan-broadcast" },
+                ],
+            },
+            {
+                text: "Desenvolvedores",
+                items: [
+                    { text: "Contribuindo", link: "/pt/developer/contributing" },
+                    { text: "Introdução", link: "/pt/developer/introduction" },
+                    {
+                        text: "Rede",
+                        link: "/pt/developer/networking/networking",
+                        items: [
+                            { text: "Autenticação", link: "/pt/developer/networking/authentication" },
+                            { text: "RCON", link: "/pt/developer/networking/rcon" },
+                        ]
+                    },
+                    { text: "Mundo", link: "/pt/developer/world" },
+                    { text: "Desenvolvimento Mobile", link: "/pt/developer/mobile" },
+                ],
+            },
+            {
+                text: "Desenvolvimento de Plugins",
+                items: [
+                    {
+                        text: "Introdução",
+                        link: "/pt/plugin-dev/introduction",
+                    },
+                    {
+                        text: "Exemplos de Plugin",
+                        link: "/pt/plugin-dev/plugin-template/introduction",
+                        items: [
+                            {
+                                text: "Criando um projeto",
+                                link: "/pt/plugin-dev/plugin-template/creating-project",
+                            },
+                            {
+                                text: "Lógica básica",
+                                link: "/pt/plugin-dev/plugin-template/basic-logic",
+                            },
+                            {
+                                text: "Gerenciador de eventos",
+                                link: "/pt/plugin-dev/plugin-template/join-event",
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                text: "Solução de Problemas",
+                items: [
+                    {
+                        text: "Problemas Comuns",
+                        link: "/pt/troubleshooting/common_issues.md",
+                    },
+                ],
+            },
+        ],
+
+        socialLinks: [
+            { icon: "github", link: "https://github.com/Pumpkin-MC/Pumpkin" },
+            { icon: "discord", link: "https://discord.gg/RNm224ZsDq" },
+        ],
+
+        logo: "/assets/favicon.ico",
+        footer: {
+            message: "Distribuído sob a Licença MIT.",
+            copyright: `Copyright © 2024-${new Date().getFullYear()} Aleksandr Medvedev`,
+        },
+        editLink: {
+            pattern:
+                "https://github.com/Pumpkin-MC/Pumpkin-Website/blob/master/docs/:path",
+            text: "Edite esta página no GitHub",
+        },
+        lastUpdated: {
+            text: "Atualizado em",
+            formatOptions: {
+                dateStyle: "medium",
+                timeStyle: "medium",
+            },
+        },
+        outline: "deep",
+    }
+});

--- a/docs/pt/about/benchmarks.md
+++ b/docs/pt/about/benchmarks.md
@@ -1,0 +1,187 @@
+# Benchmarks
+
+Aqui, softwares de servidores Minecraft comuns são comparados com o Pumpkin.
+
+> [!CAUTION] CUIDADO
+> **Esta comparação é injusta.** Pumpkin atualmente tem muito menos recursos que outros servidores, o que pode sugerir que ele usa menos recursos.
+> Também é importante considerar que outros servidores tiveram anos para otimizar.
+> Forks do Vanilla, que não precisam reescrever toda a lógica do Vanilla, podem se concentrar exclusivamente em otimizações.
+
+![Screenshot From 2024-10-15 16-42-53](https://github.com/user-attachments/assets/e08fbb00-42fe-4479-a03b-11bb6886c91a)
+
+## Especificações
+
+#### Técnicas
+
+**Software**
+
+-   Distribuição: Manjaro Linux
+-   Arquitetura: x86_64 (64-bit)
+-   Versão do Kernel: 6.11.3-arch1-1
+
+**Hardware**
+
+-   Placa-mãe: MAG B650 TOMAHAWK WIFI
+-   CPU: AMD Ryzen 7600X 6-Core
+-   RAM: Corsair 2x16GB DDR5 6000Mhz
+-   Armazenamento: Samsung 990 PRO 1TB PCIe 4.0 M.2 SSD
+-   Refrigeração: be quiet Dark Rock Elite
+
+**Rust**
+
+-   Toolchain: stable-x86_64-unknown-linux-gnu (1.81.0)
+-   Compilador Rust: rustc 1.81.0 (eeb90cda1 2024-09-04)
+
+**Java**
+
+-   Versão do JDK: OpenJDK 23 64-Bit 2024-09-17
+-   Versão do JRE: OpenJDK Runtime Environment (build 23+37)
+-   Fornecedor: Oracle
+
+#### Jogo
+
+-   Versão do Minecraft: 1.21.1
+-   Distância de visão: 10
+-   Distância simulada: 10
+-   Modo online: falso
+-   Rcon: falso
+
+<sub><sup>O modo online foi desativado para facilitar os testes com contas não premium.</sup></sub>
+
+> [!NOTE] NOTA
+> Todos os testes foram realizados várias vezes para obter resultados mais precisos.
+> Todos os jogadores não se moveram ao nascer. Apenas os 8 primeiros chunks foram carregados.
+> Todos os servidores usaram sua própria geração de terreno. Nenhum mundo foi pré-carregado.
+
+> [!IMPORTANT] IMPORTANTE
+> `CPU Max` geralmente é maior com um jogador, pois os chunks iniciais estão sendo carregados.
+
+## Pumpkin
+
+Build: [8febc50](https://github.com/Snowiiii/Pumpkin/commit/8febc5035d5611558c13505b7724e6ca284e0ada)
+
+Argumentos de compilação: `--release`
+
+Argumentos de execução:
+
+**Tamanho do arquivo:** <FmtNum :n=12.3 />MB
+
+**Tempo de inicialização:** <FmtNum :n=8 />ms
+
+**Tempo de desligamento:** <FmtNum :n=0 />ms
+
+| Jogadores | RAM                   | CPU Ocioso       | CPU Máx            |
+| --------- | --------------------- | ---------------- | ------------------ |
+| 0         | <FmtNum :n=392.2 />KB | <FmtNum :n=0 />% | <FmtNum :n=0 />%   |
+| 1         | <FmtNum :n=24.9 />MB  | <FmtNum :n=0 />% | <FmtNum :n=4 />%   |
+| 2         | <FmtNum :n=25.1 />MB  | <FmtNum :n=0 />% | <FmtNum :n=0.6 />% |
+| 5         | <FmtNum :n=26 />MB    | <FmtNum :n=0 />% | <FmtNum :n=1 />%   |
+| 10        | <FmtNum :n=27.1 />MB  | <FmtNum :n=0 />% | <FmtNum :n=1.5 />% |
+
+<sub><sup>Pumpkin faz cache dos chunks já carregados, resultando em nenhum uso extra de RAM além dos dados do jogador e uso mínimo de CPU.</sup></sub>
+
+#### Tempo de compilação
+
+Compilando do zero:
+
+**Debug:** <FmtNum :n=10.35 />sec  
+**Release:** <FmtNum :n=38.40 />sec
+
+Recompilação (pumpkin crate):
+
+**Debug:** <FmtNum :n=1.82 />sec  
+**Release:** <FmtNum :n=28.68 />sec
+
+## Vanilla
+
+Release: [1.21.1](https://piston-data.mojang.com/v1/objects/59353fb40c36d304f2035d51e7d6e6baa98dc05c/server.jar)
+
+Argumentos de compilação:
+
+Argumentos de execução: `nogui`
+
+**Tamanho do arquivo:** <FmtNum :n=51.6 />MB
+
+**Tempo de inicialização:** <FmtNum :n=7 />sec
+
+**Tempo de desligamento:** <FmtNum :n=4 />sec
+
+| Jogadores | RAM                  | CPU ocioso                               | CPU Máx            |
+| --------- | -------------------- | ---------------------------------------- | ------------------ |
+| 0         | <FmtNum n="860" />MB | <FmtNum n="0.1" /> - <FmtNum n="0.3" />% | <FmtNum n="51" />% |
+| 1         | <FmtNum n="1.5" />GB | <FmtNum n="0.9" /> - <FmtNum n="1" />%   | <FmtNum n="41" />% |
+| 2         | <FmtNum n="1.6" />GB | <FmtNum n="1" /> - <FmtNum n="1.1" />%   | <FmtNum n="10" />% |
+| 5         | <FmtNum n="1.8" />GB | <FmtNum n="2" />%                        | <FmtNum n="20" />% |
+| 10        | <FmtNum n="2.2" />GB | <FmtNum n="4" />%                        | <FmtNum n="24" />% |
+
+## Paper
+
+Build: [122](https://api.papermc.io/v2/projects/paper/versions/1.21.1/builds/122/downloads/paper-1.21.1-122.jar)
+
+Argumentos de compilação:
+
+Argumentos de execução: `nogui`
+
+**Tamanho do arquivo:** <FmtNum :n=49.4 />MB
+
+**Tempo de inicialização:** <FmtNum :n=7 />sec
+
+**Tempo de desligamento:** <FmtNum :n=3 />sec
+
+| Jogadores | RAM                 | CPU ocioso                             | CPU Máx           |
+| --------- | ------------------- | -------------------------------------- | ----------------- |
+| 0         | <FmtNum :n=1.1 />GB | <FmtNum :n=0.2 /> - <FmtNum :n=0.3 />% | <FmtNum :n=36 />% |
+| 1         | <FmtNum :n=1.7 />GB | <FmtNum :n=0.9 /> - <FmtNum :n=1.0 />% | <FmtNum :n=47 />% |
+| 2         | <FmtNum :n=1.8 />GB | <FmtNum :n=1 /> - <FmtNum :n=1.1 />%   | <FmtNum :n=10 />% |
+| 5         | <FmtNum :n=1.9 />GB | <FmtNum :n=1.5 />%                     | <FmtNum :n=15 />% |
+| 10        | <FmtNum :n=2 />GB   | <FmtNum :n=3 />%                       | <FmtNum :n=20 />% |
+
+## Purpur
+
+Build: [2324](https://api.purpurmc.org/v2/purpur/1.21.1/2324/download)
+
+Argumentos de compilação:
+
+Argumentos de execução: `nogui`
+
+**Tamanho do arquivo:** <FmtNum :n=53.1 />MB
+
+**Tempo de inicialização:** <FmtNum :n=8 />sec
+
+**Tempo de desligamento:** <FmtNum :n=4 />sec
+
+| Jogadores | RAM                 | CPU ocioso                             | CPU Máx           |
+| --------- | ------------------- | -------------------------------------- | ----------------- |
+| 0         | <FmtNum :n=1.4 />GB | <FmtNum :n=0.2 /> - <FmtNum :n=0.3 />% | <FmtNum :n=25 />% |
+| 1         | <FmtNum :n=1.6 />GB | <FmtNum :n=0.7 /> - <FmtNum :n=1.0 />% | <FmtNum :n=35 />% |
+| 2         | <FmtNum :n=1.7 />GB | <FmtNum :n=1.1 /> - <FmtNum :n=1.3 />% | <FmtNum :n=9 />%  |
+| 5         | <FmtNum :n=1.9 />GB | <FmtNum :n=1.6 />%                     | <FmtNum :n=20 />% |
+| 10        | <FmtNum :n=2.2 />GB | <FmtNum :n=2 /> - <FmtNum :n=2.5 />%   | <FmtNum :n=26 />% |
+
+## Minestom
+
+Commit: [0ca1dda2fe](https://github.com/Minestom/Minestom/commit/0ca1dda2fe11390a1b89a228bbe7bf78fefc73e1)
+
+Argumentos de compilação:
+
+Argumentos de execução:
+
+**Idioma:** Benchmarks executados com Kotlin 2.0.0 (Minestom é feito com Java)
+
+**Tamanho do arquivo:** <FmtNum :n=2.8 />MB (Biblioteca)
+
+**Tempo de inicialização:** <FmtNum :n=310 />ms
+
+**Tempo de desligamento:** <FmtNum :n=0 />ms
+
+<sub>[Usado o código do exemplo de](https://minestom.net/docs/setup/your-first-server)</sub>
+
+| Jogadores | RAM                 | CPU ocioso                             | CPU Máx          |
+| --------- | ------------------- | -------------------------------------- | ---------------- |
+| 0         | <FmtNum :n=228 />MB | <FmtNum :n=0.1 /> - <FmtNum :n=0.3 />% | <FmtNum :n=1 />% |
+| 1         | <FmtNum :n=365 />MB | <FmtNum :n=0.9 /> - <FmtNum :n=1.0 />% | <FmtNum :n=5 />% |
+| 2         | <FmtNum :n=371 />MB | <FmtNum :n=1 /> - <FmtNum :n=1.1 />%   | <FmtNum :n=4 />% |
+| 5         | <FmtNum :n=390 />MB | <FmtNum :n=1.0 />%                     | <FmtNum :n=6 />% |
+| 10        | <FmtNum :n=421 />MB | <FmtNum :n=3 />%                       | <FmtNum :n=9 />% |
+
+Benchmarks realizados em <FmtDateTime :d="new Date('2024-10-15T16:34Z')" />

--- a/docs/pt/about/introduction.md
+++ b/docs/pt/about/introduction.md
@@ -1,0 +1,33 @@
+# Pumpkin
+
+Pumpkin é um servidor de Minecraft construído inteiramente em **Rust**, oferecendo uma experiência rápida, eficiente e personalizável. Ele prioriza o desempenho e experiência dos jogadores, enquanto adere às mecânicas fundamentais do jogo.
+
+<picture>
+  <source srcset="/assets/introduction-preview-2560x1440.png" media="(min-width: 2560px)">
+  <source srcset="/assets/introduction-preview-1280x720.png" media="(min-width: 1280px)">
+  <source srcset="/assets/introduction-preview-640x360.png" media="(min-width: 640px)">
+  <img src="/assets/introduction-preview-1280x720.png" alt="introduction-preview">
+</picture>
+
+## O que o Pumpkin quer alcançar
+
+-   **Performance**: Aproveita o multi-threading para máxima velocidade e eficiência.
+-   **Compatibilidade**: Suporta a versão mais recente do servidor Minecraft e adere às mecânicas do jogo Vanilla.
+-   **Segurança**: Prioriza a segurança, prevenindo exploits de segurança conhecidos.
+-   **Flexibilidade**: Altamente configurável, com a capacidade de desativar funcionalidades desnecessárias.
+-   **Extensibilidade**: Oferece uma base para o desenvolvimento de plugins.
+
+## O que o Pumpkin não fará
+
+-   Ser compatível com plugins ou mods de outros servidores.
+
+> [!IMPORTANT] IMPORTANTE
+> O Pumpkin está atualmente em desenvolvimento acelerado. Confira nosso [Projeto no Github](https://github.com/orgs/Pumpkin-MC/projects/3) para ver o progresso atual.
+
+## Vanilla
+
+O Pumpkin foi projetado para replicar a lógica do Minecraft Vanilla o mais fielmente possível, garantindo uma experiência de jogo familiar. No entanto, também adicionamos novos recursos para aprimorar o gameplay.
+
+### Redstone
+
+Ao contrário de outros forks que podem comprometer as mecânicas de redstone, o Pumpkin mantém o comportamento de redstone do Vanilla. Se você deseja experimentar modificações em redstone ou busca otimizações de desempenho, você tem flexibilidade para fazer isso por meio das nossas configurações ajustáveis.

--- a/docs/pt/about/quick-start.md
+++ b/docs/pt/about/quick-start.md
@@ -1,0 +1,73 @@
+# Primeiros Passos
+
+**Status Atual:**
+Pré-lançamento: Atualmente em desenvolvimento e ainda não pronto para lançamento oficial.
+
+## Rust
+
+Para rodar o Pumpkin com Rust, certifique-se de ter o [Rust](https://www.rust-lang.org/tools/install) instalado.
+
+1. Clone o repositório:
+
+```shell
+git clone https://github.com/Pumpkin-MC/Pumpkin.git
+cd Pumpkin
+```
+
+2. **Opcional:** Se desejar, você pode colocar um mundo Vanilla no diretório `Pumpkin/`. Apenas nomeie a pasta do mundo como `world`.
+
+3. Execute:
+
+> [!NOTE] NOTA
+> O processo de construção pode demorar um pouco, devido a otimizações pesadas para builds de lançamento.
+
+```shell
+cargo run --release
+```
+
+4. **Opcional:** Se quiser usar os recursos do seu processador, você pode configurar a flag do compilador Rust `target-cpu=native`.
+
+```shell
+RUSTFLAGS='-C target-cpu=native' cargo run --release
+```
+
+## Docker
+
+> [!IMPORTANT] IMPORTANTE
+> O suporte ao Docker está atualmente em fase experimental.
+
+Se ainda não tiver, você precisa [instalar o Docker](https://docs.docker.com/engine/install/). Após instalar o Docker, você pode rodar o seguinte comando para iniciar o servidor:
+
+```shell
+docker run --rm \
+    -p <exposed_port>:25565  \
+    -v <server_data_location>:/pumpkin \
+    -it ghcr.io/pumpkin-mc/pumpkin:master
+```
+
+-   `<exposed_port>`: A porta que você deseja usar para conectar ao Pumpkin, por exemplo `25565`.
+-   `<server_data_location>`: O local onde você deseja que as configurações e dados do servidor sejam armazenados, por exemplo `./data`.
+
+### Exemplo
+
+Para rodar o Pumpkin na porta `25565` e armazenar os dados em um diretório chamado `./data`, você executaria o seguinte comando:
+
+```shell
+docker run --rm \
+    -p 25565:25565 \
+    -v ./data:/pumpkin \
+    -it ghcr.io/pumpkin-mc/pumpkin:master
+```
+
+## Servidor de Teste
+
+Pumpkin tem um servidor de teste mantido por @kralverde. Ele roda no commit mais recente da branch master do Pumpkin.
+
+-   **IP:** pumpkin.kralverde.dev
+
+**Especificações:**
+
+-   SO: Debian GNU/Linux bookworm 12.7 x86_64
+-   Kernel: Linux 6.1.0-21-cloud-amd64
+-   CPU: Intel Core (Haswell, sem TSX) (2) @ 2.40 GHz
+-   RAM: 4GB DIMM

--- a/docs/pt/config/authentication.md
+++ b/docs/pt/config/authentication.md
@@ -1,0 +1,216 @@
+# Autenticação
+
+Servidores autenticam com os servidores de sessão da Mojang para garantir que o cliente esteja jogando em uma conta legítima e paga. O Pumpkin permite configurar a autenticação de forma completa.
+
+## Configurando a Autenticação
+
+> [!WARNING] AVISO
+> A maioria dos servidores não deve alterar a configuração padrão de autenticação. Fazer isso pode ter consequências indesejadas. **Altere essas configurações somente se souber o que está fazendo!**
+
+#### `enabled`: Booleano
+
+Define se a autenticação está habilitada ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[authentication]
+enabled = false
+```
+
+:::
+
+#### `prevent_proxy_connections`: Booleano
+
+Define se deve bloquear conexões de proxy ou não.
+
+:::code-group
+
+```toml [features.toml] {3}
+[authentication]
+enabled = true
+prevent_proxy_connections = true
+```
+
+:::
+
+#### `auth_url`: String (opcional)
+
+A URL para autenticar. Usa os servidores de sessão da Mojang para autenticação se não for especificada.
+
+##### Argumentos
+
+| Argumento       | Descrição                  |
+| --------------- | -------------------------- |
+| `{username}`    | Nome de usuário do jogador |
+| `{server_hash}` | Hash do servidor           |
+
+:::code-group
+
+```toml [features.toml] {2}
+[authentication]
+auth_url = "[servidor de autenticação personalizado aqui]"
+```
+
+:::
+
+#### `prevent_proxy_connection_auth_url`: String (opcional)
+
+A URL para autenticar quando `prevent_proxy_connections` está habilitado. Usa os servidores de sessão da Mojang para autenticação se não for especificada.
+
+##### Argumentos
+
+| Argumento       | Descrição                  |
+| --------------- | -------------------------- |
+| `{username}`    | Nome de usuário do jogador |
+| `{server_hash}` | Hash do servidor           |
+| `{ip}`          | Endereço IP do jogador     |
+
+:::code-group
+
+```toml [features.toml] {2}
+[authentication]
+prevent_proxy_connection_auth_url = "[servidor de autenticação personalizado aqui]"
+```
+
+:::
+
+### Perfil do Jogador
+
+#### `allow_banned_players`: Booleano
+
+Permitir jogadores banidos pela Mojang.
+
+:::code-group
+
+```toml [features.toml] {2}
+[authentication.player_profile]
+allow_banned_players = true
+```
+
+:::
+
+#### `allowed_actions`: Array de Strings
+
+Quais ações são permitidas se `allow_banned_players` estiver habilitado.
+
+:::code-group
+
+```toml [features.toml] {3}
+[authentication.player_profile]
+allow_banned_players = true
+allowed_actions = ["FORCED_NAME_CHANGE", "USING_BANNED_SKIN"]
+```
+
+:::
+
+### Texturas
+
+#### `enabled`: Booleano
+
+Define se as texturas dos jogadores (por exemplo, skins/capas) devem ser filtradas/validadas.
+
+:::code-group
+
+```toml [features.toml] {2}
+[authentication.textures]
+enabled = true
+```
+
+:::
+
+#### `allowed_url_schemes`: Array de Strings
+
+Esquemas URL permitidos para texturas.
+
+:::code-group
+
+```toml [features.toml] {3}
+[authentication.textures]
+enabled = true
+allowed_url_schemes = ["http", "https"]
+```
+
+:::
+
+#### `allowed_url_domains`: Array de Strings
+
+Domínios URL permitidos para texturas.
+
+:::code-group
+
+```toml [features.toml] {3}
+[authentication.textures]
+enabled = true
+allowed_url_domains = [".minecraft.net", ".mojang.com"]
+```
+
+:::
+
+### Tipos de Texturas
+
+#### `skin`: Booleano
+
+Define se deve usar skins dos jogadores ou não.
+
+:::code-group
+
+```toml [features.toml] {3}
+[authentication.textures.types]
+skin = true
+```
+
+:::
+
+#### `cape`: Booleano
+
+Define se deve usar capas dos jogadores ou não.
+
+:::code-group
+
+```toml [features.toml] {3}
+[authentication.textures.types]
+cape = true
+```
+
+:::
+
+#### `elytra`: Booleano
+
+Define se deve usar elytras dos jogadores ou não.
+
+:::code-group
+
+```toml [features.toml] {3}
+[authentication.textures.types]
+elytra = true
+```
+
+:::
+
+## Configuração Padrão
+
+Por padrão, a autenticação está habilitada e usa os servidores da Mojang. Aqui está a configuração padrão:
+:::code-group
+
+```toml [features.toml]
+[authentication]
+enabled = true
+prevent_proxy_connections = false
+
+[authentication.player_profile]
+allow_banned_players = false
+allowed_actions = ["FORCED_NAME_CHANGE", "USING_BANNED_SKIN"]
+
+[authentication.textures]
+enabled = true
+allowed_url_schemes = ["http", "https"]
+allowed_url_domains = [".minecraft.net", ".mojang.com"]
+
+[authentication.textures.types]
+skin = true
+cape = true
+elytra = true
+```
+
+:::

--- a/docs/pt/config/basic.md
+++ b/docs/pt/config/basic.md
@@ -1,0 +1,225 @@
+# Configuração Básica
+
+Representando `configuration.toml`
+
+## Endereço do Servidor
+
+O endereço para vincular o servidor.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+server_address = "0.0.0.0:25565"
+```
+
+:::
+
+## Seed
+
+A seed para a geração do mundo.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+seed = ""
+```
+
+:::
+
+## Limite de Jogadores
+
+O número máximo de jogadores permitidos no servidor.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+max_players = 100000
+```
+
+:::
+
+## Distância de Visão
+
+A distância máxima de visão para os jogadores.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+view_distance = 10
+```
+
+:::
+
+## Distância de Simulação
+
+A distância máxima de simulação para os jogadores.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+simulation_distance = 10
+```
+
+:::
+
+## Dificuldade Padrão
+
+A dificuldade padrão do jogo.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+default_difficulty = "Normal"
+```
+
+:::
+
+```toml
+Peaceful
+Easy
+Normal
+Hard
+```
+
+## Nível de Permissão de Operação
+
+O nível de permissão atribuído pelo comando `/op`.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+op_permission_level = 4
+```
+
+:::
+
+## Permitir Nether
+
+Se a dimensão Nether está habilitada.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+allow_nether = true
+```
+
+:::
+
+## Hardcore
+
+Se o servidor está no modo hardcore.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+hardcore = false
+```
+
+:::
+
+## Modo Online
+
+Se o modo online está habilitado. Requer contas válidas do Minecraft.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+online_mode = true
+```
+
+:::
+
+## Criptografia
+
+Se a criptografia de pacotes está habilitada.
+
+> [!IMPORTANTE]
+> Requerido quando o modo online está habilitado.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+encryption = true
+```
+
+:::
+
+## MOTD
+
+Mensagem do Dia; a descrição do servidor exibida na tela de status.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+motd = "A Blazing fast Pumpkin Server!"
+```
+
+:::
+
+## TPS
+
+A taxa de tique (tick rate) alvo do servidor.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+tps = 20.0
+```
+
+:::
+
+## Modo de Jogo Padrão
+
+O modo de jogo padrão para os jogadores.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+default_gamemode = "Survival"
+```
+
+:::
+
+```toml
+Undefined
+Survival
+Creative
+Adventure
+Spectator
+```
+
+## Limpeza de IPs
+
+Se os endereços IP dos jogadores devem ser removidos dos logs.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+scrub_ips = true
+```
+
+:::
+
+## Usar Favicon
+
+Se o servidor deve usar um favicon ou não.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+use_favicon = true
+```
+
+:::
+
+## Caminho do Favicon
+
+O caminho para o favicon do servidor.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+favicon_path = "icon.png"
+```
+
+:::

--- a/docs/pt/config/commands.md
+++ b/docs/pt/config/commands.md
@@ -1,0 +1,58 @@
+# Comandos
+
+Pumpkin suporta comandos Vanilla e permite configurar onde eles podem ser executados.
+
+## Configurando Comandos
+
+#### `use_console`: Booleano
+
+Se os comandos do console são aceitos ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[commands]
+use_console = false
+```
+
+:::
+
+#### `log_console`: Booleano
+
+Se os comandos dos jogadores devem ser registrados no console ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[commands]
+log_console = false
+```
+
+:::
+
+## Nível de permissão de operação
+
+O nível de permissão padrão para todos os jogadores.
+
+:::code-group
+
+```toml [configuration.toml] {2}
+default_op_level = 0
+```
+
+:::
+
+## Configuração Padrão
+
+Por padrão, Pumpkin permitirá comandos da console e registrará todos os comandos executados pelos jogadores.
+
+:::code-group
+
+```toml [features.toml]
+[commands]
+use_console = true
+log_console = true
+default_op_level = 0
+```
+
+:::

--- a/docs/pt/config/compression.md
+++ b/docs/pt/config/compression.md
@@ -1,0 +1,65 @@
+# Compressão
+
+Compressão é utilizada para reduzir o tamanho dos pacotes. Isso é benéfico para reduzir a largura de banda do lado do servidor e também para ajudar jogadores com conexões de internet mais lentas.
+
+## Configurando a compressão
+
+#### `enabled`: Booleano
+
+Se a compressão de pacotes está habilitada ou não.
+
+> [!TIP] DICA
+> Pode ser benéfico desabilitar a compressão se o servidor estiver atrás de um proxy.
+
+:::code-group
+
+```toml [features.toml] {2}
+[packet_compression]
+enabled = true
+```
+
+:::
+
+#### `threshold`: Inteiro (0-1024)
+
+O tamanho mínimo do pacote antes que o servidor tente comprimir o pacote.
+
+> [!CAUTION] CUIDADO
+> Aumentar este valor pode prejudicar jogadores com conexões mais lentas.
+
+:::code-group
+
+```toml [features.toml] {2}
+[packet_compression]
+threshold = 256
+```
+
+:::
+
+#### `level`: Inteiro (0-9)
+
+Um valor entre 0 e 9: 0 para desabilitar a compressão, 1 sendo a compressão mais rápida (à custa do tamanho), e 9 sendo a compressão máxima (à custa da velocidade).
+
+:::code-group
+
+```toml [features.toml] {2}
+[packet_compression]
+level = 4
+```
+
+:::
+
+## Configuração Padrão
+
+Por padrão, a compressão está habilitada.
+
+:::code-group
+
+```toml [features.toml]
+[packet_compression]
+enabled = true
+threshold = 256
+level = 4
+```
+
+:::

--- a/docs/pt/config/introduction.md
+++ b/docs/pt/config/introduction.md
@@ -1,0 +1,23 @@
+### Configuração
+
+Pumpkin oferece um sistema de configuração robusto que permite aos usuários personalizar vários aspectos do comportamento do servidor sem depender de plugins externos. Isso proporciona flexibilidade e controle sobre o funcionamento do servidor.
+
+### Básica / Avançada
+
+A configuração do Pumpkin é dividida em uma configuração "básica", feita para mudanças rápidas e importantes, e uma configuração mais "avançada".
+
+-   `configuration.toml`: simples e pode ser comparado ao `server.properties` do vanilla.
+-   `features.toml`: projetado para reunir todos os recursos do Pumpkin em um único lugar, tornando-se uma configuração mais abrangente.
+
+### Versão do Servidor
+
+Pumpkin tem como objetivo oferecer suporte à versão mais recente do Minecraft. Se você deseja hospedar um servidor Pumpkin para qualquer outra versão, existe um projeto chamado [ViaProxy](https://github.com/ViaVersion/ViaProxy).
+
+-   Certifique-se de permitir conexões de proxy.
+-   Pumpkin e o ViaProxy não possuem conexão; não nos envie problemas relacionados ao código deles. Além disso, este é um proxy de terceiros e o Pumpkin não se responsabiliza pelos resultados, bons ou ruins.
+
+#### Principais Características:
+
+-   **Personalização Extensa**: Configure configurações do servidor, comportamento dos jogadores, geração de mundos e muito mais.
+-   **Otimização de Desempenho**: Otimize o desempenho do servidor por meio de ajustes na configuração.
+-   **Personalização Sem Plugins**: Alcance as mudanças desejadas sem a necessidade de plugins adicionais.

--- a/docs/pt/config/lan-broadcast.md
+++ b/docs/pt/config/lan-broadcast.md
@@ -1,0 +1,67 @@
+# Transmissão LAN
+
+Pumpkin pode divulgar o servidor na rede para facilitar a conexão de jogadores locais ao servidor.
+
+## Configurando a Transmissão LAN
+
+#### `enabled`: Booleano
+
+Se a transmissão LAN está habilitada ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[lan_broadcast]
+enabled = true
+```
+
+:::
+
+#### `motd`: String (opcional)
+
+A mensagem de boas-vindas (MOTD) a ser transmitida para os clientes; usa a MOTD do servidor por padrão.
+
+> [!CAUTION] CUIDADO
+> A MOTD da transmissão LAN não suporta múltiplas linhas, cores RGB ou gradientes. O Pumpkin não verifica a MOTD antes de transmiti-la. Se a MOTD do servidor usar esses componentes, considere definir este campo para que os clientes vejam uma MOTD adequada.
+
+:::code-group
+
+```toml [features.toml] {3}
+[lan_broadcast]
+enabled = true
+motd = "[sua MOTD aqui]"
+```
+
+:::
+
+#### `port`: Inteiro (0-65535) (opcional)
+
+A porta para a qual o servidor será vinculado. Se não especificado, será vinculado à porta 0 (qualquer porta disponível no sistema).
+
+> [!IMPORTANT] IMPORTANTE
+> O protocolo define qual porta será usada para a transmissão. Esta opção existe apenas para especificar qual porta vincular no host. Ela existe exclusivamente para que a porta seja previsível.
+
+:::code-group
+
+```toml [features.toml] {3}
+[lan_broadcast]
+enabled = true
+port = 46733
+```
+
+:::
+
+## Configuração Padrão
+
+Por padrão, a transmissão LAN está desabilitada.
+
+:::code-group
+
+```toml [features.toml]
+[lan_broadcast]
+enabled = false
+motd = "[MOTD do servidor aqui]"
+port = 0
+```
+
+:::

--- a/docs/pt/config/logging.md
+++ b/docs/pt/config/logging.md
@@ -1,0 +1,113 @@
+# Registro de Logs
+
+Pumpkin permite personalizar o que você deseja registrar em seus logs.
+
+## Configurando o Registro de Logs
+
+#### `enabled`: Booleano
+
+Se o registro de logs está habilitado ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[logging]
+enabled = true
+```
+
+:::
+
+#### `level`: Enum
+
+O nível de verbosidade do log. Os valores possíveis são:
+
+-   Off (Desligado)
+-   Error (Erro)
+-   Warn (Aviso)
+-   Info (Informação)
+-   Debug (Depuração)
+-   Trace (Rastreamento)
+
+:::code-group
+
+```toml [features.toml] {3}
+[logging]
+enabled = true
+level = "Debug"
+```
+
+:::
+
+#### `env`: Booleano
+
+Se deve permitir escolher o nível de log configurando a variável de ambiente `RUST_LOG` ou não.
+
+:::code-group
+
+```toml [features.toml] {3}
+[logging]
+enabled = true
+env = true
+```
+
+:::
+
+#### `threads`: Booleano
+
+Se deve exibir as threads nas mensagens de log ou não.
+
+:::code-group
+
+```toml [features.toml] {3}
+[logging]
+enabled = true
+threads = false
+```
+
+:::
+
+#### `color`: Booleano
+
+Se deve imprimir no console com cores ou não.
+
+:::code-group
+
+```toml [features.toml] {3}
+[logging]
+enabled = true
+color = false
+```
+
+:::
+
+#### `timestamp`: Booleano
+
+Se deve imprimir a data e hora na mensagem ou não.
+
+:::code-group
+
+```toml [features.toml] {3}
+[logging]
+enabled = true
+timestamp = false
+```
+
+:::
+
+## Configuração Padrão
+
+Por padrão, o registro de logs está habilitado no nível `Info` e imprimirá com cores, threads e data/hora.
+
+:::code-group
+
+```toml [features.toml]
+[logging]
+enabled = true
+level = "Info"
+env = false
+threads = true
+color = true
+timestamp = true
+```
+
+:::

--- a/docs/pt/config/proxy.md
+++ b/docs/pt/config/proxy.md
@@ -1,0 +1,91 @@
+# Proxy
+
+Muitos servidores utilizam proxies para gerenciar conexões e distribuir jogadores entre servidores. Pumpkin suporta os seguintes protocolos de proxy:
+
+-   [Velocity](https://papermc.io/software/velocity)
+-   [BungeeCord](https://www.spigotmc.org/wiki/bungeecord-installation/)
+
+> [!TIP] DICA
+> Velocity é recomendado para a maioria das redes de servidores. Velocity é moderno e mais eficiente em comparação ao BungeeCord.
+
+## Configurando Proxy
+
+#### `enabled`: Booleano
+
+Habilita o suporte para proxies.
+
+:::code-group
+
+```toml [features.toml]{2}
+[proxy]
+enabled = true
+```
+
+:::
+
+### Velocity
+
+#### `enabled`: Booleano
+
+Se o suporte ao Velocity está habilitado ou não.
+
+:::code-group
+
+```toml [features.toml]{2}
+[proxy.velocity]
+enabled = true
+```
+
+:::
+
+#### `secret`: String
+
+O segredo configurado no Velocity.
+
+:::code-group
+
+```toml [features.toml]{3}
+[proxy.velocity]
+enabled = true
+secret = "[segredo do proxy aqui]"
+```
+
+:::
+
+### BungeeCord
+
+#### `enabled`: Booleano
+
+Se o suporte ao BungeeCord está habilitado ou não.
+
+:::code-group
+
+```toml [features.toml]{2}
+[proxy.bungeecord]
+enabled = true
+```
+
+:::
+
+> [!CAUTION] CUIDADO
+> BungeeCord não consegue verificar se as informações do jogador são provenientes do seu proxy ou de um impostor. Certifique-se de que o firewall do servidor esteja configurado corretamente.
+
+## Configuração Padrão
+
+Por padrão, o suporte a proxies está desativado. Aqui está a configuração padrão:
+
+:::code-group
+
+```toml [features.toml]
+[proxy]
+enabled = false
+
+[proxy.velocity]
+enabled = false
+secret = ""
+
+[proxy.bungeecord]
+enabled = false
+```
+
+:::

--- a/docs/pt/config/pvp.md
+++ b/docs/pt/config/pvp.md
@@ -1,0 +1,87 @@
+# PVP
+
+PVP é uma parte fundamental da mecânica Vanilla, com até mesmo a menor mudança afetando a jogabilidade. Pumpkin permite que você configure completamente o PVP.
+
+## Configurando o PVP
+
+#### `enabled`: Booleano
+
+Se o PVP está habilitado ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[pvp]
+enabled = true
+```
+
+:::
+
+#### `hurt_animation`: Booleano
+
+Se deve exibir a animação de dano vermelho e o movimento de câmera (FOV) ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[pvp]
+hurt_animation = true
+```
+
+:::
+
+#### `protect_creative`: Booleano
+
+Se deve proteger jogadores no modo criativo contra o PVP ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[pvp]
+protect_creative = true
+```
+
+:::
+
+#### `knockback`: Booleano
+
+Se os ataques devem ter repulsão (knockback) ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[pvp]
+knockback = true
+```
+
+:::
+
+#### `swing`: Booleano
+
+Se os jogadores devem balançar a arma ao atacar ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[pvp]
+swing = true
+```
+
+:::
+
+## Configuração Padrão
+
+Por padrão, todas as opções de PVP estão habilitadas para coincidir com o comportamento Vanilla.
+
+:::code-group
+
+```toml [features.toml]
+[pvp]
+enabled = true
+hurt_animation = true
+protect_creative = true
+knockback = true
+swing = true
+```
+
+:::

--- a/docs/pt/config/query.md
+++ b/docs/pt/config/query.md
@@ -1,0 +1,46 @@
+# Query
+
+O protocolo Query é uma maneira simples de consultar o status do servidor. Pumpkin oferece suporte total para o protocolo Query.
+
+## Configurando o Query
+
+#### `enabled`: Booleano
+
+Se deve ouvir ou não as requisições do protocolo Query.
+
+:::code-group
+
+```toml [features.toml] {2}
+[query]
+enabled = true
+```
+
+:::
+
+#### `port`: Inteiro (0-65535) (opcional)
+
+A porta em que o servidor deve ouvir as requisições do protocolo Query. Se não especificado, será utilizada a mesma porta do servidor.
+
+:::code-group
+
+```toml [features.toml] {3}
+[query]
+enabled = true
+port = 12345
+```
+
+:::
+
+## Configuração Padrão
+
+Por padrão, o Query está desabilitado. Ele será executado na porta do servidor se habilitado, a menos que especificado explicitamente.
+
+:::code-group
+
+```toml [features.toml]
+[query]
+enabled = true
+port = 25565
+```
+
+:::

--- a/docs/pt/config/rcon.md
+++ b/docs/pt/config/rcon.md
@@ -1,0 +1,134 @@
+# RCON
+
+RCON é um protocolo que permite gerenciar o servidor remotamente a partir de outro dispositivo. Pumpkin oferece suporte completo para RCON.
+
+## Configurando o RCON
+
+#### `enabled`: Booleano
+
+:::code-group
+
+```toml [features.toml] {2}
+[rcon]
+enabled = true
+```
+
+:::
+
+#### `address`: String
+
+O endereço e a porta que o RCON deve escutar.
+
+:::code-group
+
+```toml [features.toml] {3}
+[rcon]
+enabled = true
+address = "0.0.0.0:25575"
+```
+
+:::
+
+#### `password`: String
+
+A senha a ser usada para autenticação RCON.
+
+:::code-group
+
+```toml [features.toml] {3}
+[rcon]
+enabled = true
+password = "[sua senha segura aqui]"
+```
+
+:::
+
+#### `max_connections`: Inteiro
+
+O número máximo de conexões RCON permitidas ao mesmo tempo. Defina como 0 para desabilitar o limite.
+
+:::code-group
+
+```toml [features.toml] {3}
+[rcon]
+enabled = true
+max_connections = 5
+```
+
+:::
+
+### Registro de Logs
+
+#### `log_logged_successfully`: Booleano
+
+Se os logins bem-sucedidos devem ser registrados no console ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[rcon.logging]
+log_logged_successfully = true
+```
+
+:::
+
+#### `log_wrong_password`: Booleano
+
+Se as tentativas de senha incorreta devem ser registradas no console ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[rcon.logging]
+log_wrong_password = true
+```
+
+:::
+
+#### `log_commands`: Booleano
+
+Se os comandos executados via RCON devem ser registrados no console ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[rcon.logging]
+log_commands = true
+```
+
+:::
+
+#### `log_quit`: Booleano
+
+Se a saída do cliente RCON deve ser registrada ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[rcon.logging]
+log_quit = true
+```
+
+:::
+
+## Configuração Padrão
+
+Por padrão, o RCON está desabilitado.
+
+:::code-group
+
+```toml [features.toml]
+[rcon]
+enabled = false
+address = "0.0.0.0:25575"
+password = ""
+max_connections = 0
+
+[rcon.logging]
+log_logged_successfully = true
+log_wrong_password = true
+log_commands = true
+log_quit = true
+```
+
+:::

--- a/docs/pt/config/resource-pack.md
+++ b/docs/pt/config/resource-pack.md
@@ -1,0 +1,120 @@
+# Pacote de Recursos
+
+Servidores podem enviar pacotes de recursos para os clientes a fim de alterar a aparência do jogo no cliente. Pumpkin permite que você configure completamente o pacote de recursos.
+
+> [!TIP] DICA
+> Minifique seu pacote de recursos usando o [PackSquash](https://packsquash.aylas.org/)! Isso pode ajudar os clientes a baixar o pacote de recursos mais rápido.
+
+## Configurando o Pacote de Recursos
+
+#### `enabled`: Booleano
+
+Se o pacote de recursos está habilitado ou não.
+
+:::code-group
+
+```toml [features.toml] {2}
+[resource_pack]
+enabled = true
+```
+
+:::
+
+#### `resource_pack_url`: String
+
+A URL direta de download do pacote de recursos.
+
+> [!TIP] DICA
+> Você pode hospedar o pacote de recursos gratuitamente no [MCPacks](https://mc-packs.net/).
+
+:::code-group
+
+```toml [features.toml] {3}
+[resource_pack]
+enabled = true
+resource_pack_url = "[sua URL de download aqui]"
+```
+
+:::
+
+#### `resource_pack_sha1`: String
+
+O hash SHA1 do pacote de recursos.
+
+> [!IMPORTANT] IMPORTANTE
+> Embora não seja necessário especificar, você deve informar este campo porque, caso contrário, o cliente fará o download do pacote de recursos toda vez que entrar no servidor, mesmo que não haja alterações no pacote.
+
+> [!WARNING] AVISO
+> Certifique-se de atualizar este campo se o pacote de recursos for modificado.
+
+::: detalhes Como obter o hash SHA1 do meu pacote de recursos?
+::: code-group
+
+```powershell [Windows (PowerShell)]
+Get-FileHash [arquivo] SHA1
+```
+
+```shell [Mac OS]
+shasum -a 1 [arquivo]
+```
+
+```shell [Linux]
+sha1sum [arquivo]
+```
+
+:::
+
+:::code-group
+
+```toml [features.toml] {3}
+[resource_pack]
+enabled = true
+resource_pack_sha1 = "[seu hash aqui]"
+```
+
+:::
+
+#### `prompt_message`: String
+
+A mensagem a ser exibida para o usuário quando for solicitado o download do pacote de recursos.
+
+:::code-group
+
+```toml [features.toml] {3}
+[resource_pack]
+enabled = true
+prompt_message = "[sua mensagem aqui]"
+```
+
+:::
+
+#### `force`: Booleano
+
+Se deve forçar o cliente a baixar o pacote de recursos ou não. Se o cliente recusar o download, ele será expulso do servidor.
+
+:::code-group
+
+```toml [features.toml] {3}
+[resource_pack]
+enabled = true
+force = false
+```
+
+:::
+
+## Configuração Padrão
+
+Por padrão, nenhum pacote de recursos é enviado para os clientes.
+
+:::code-group
+
+```toml [features.toml]
+[resource_pack]
+enabled = false
+resource_pack_url = ""
+resource_pack_sha1 = ""
+prompt_message = ""
+force = false
+```
+
+:::

--- a/docs/pt/developer/contributing.md
+++ b/docs/pt/developer/contributing.md
@@ -1,0 +1,73 @@
+### Contribuindo para o Pumpkin
+
+Agradecemos o seu interesse em contribuir para o Pumpkin! Este documento descreve as diretrizes para o envio de relatórios de bugs, sugestões de funcionalidades e alterações de código.
+
+### Começando
+
+A maneira mais fácil de começar é pedindo ajuda em [nosso servidor do Discord](https://discord.gg/wT8XjrjKkf).
+
+### Como Contribuir
+
+Existem várias maneiras de você contribuir para o Pumpkin:
+
+#### Reportando Bugs
+
+Se você encontrar um bug, por favor, procure por problemas existentes no rastreador de problemas primeiro.
+
+Se não encontrar um problema duplicado, abra um novo.
+
+Siga o modelo e forneça uma descrição clara do bug, incluindo os passos para reproduzi-lo, se possível.
+Capturas de tela, logs ou trechos de código também podem ser úteis.
+
+#### Sugerindo Funcionalidades
+
+Tem uma ideia de como o Pumpkin pode ser melhorado? Compartilhe seus pensamentos abrindo um problema no rastreador de problemas.
+
+Descreva a funcionalidade proposta em detalhes, incluindo seus benefícios e considerações sobre a implementação.
+
+#### Contribuindo com Código
+
+Para começar a contribuir com código para o Pumpkin, faça um fork do repositório no GitHub
+
+1. Primeiro, crie uma conta no GitHub, caso ainda não tenha uma.
+
+2. Vá até a [Organização oficial do Pumpkin no GitHub](https://github.com/Pumpkin-MC) e clique em "fork".
+
+> Criar um fork significa que você agora tem uma cópia do código-fonte do Pumpkin (isso não significa que você detém os direitos autorais).
+
+Agora que você tem uma cópia que pode editar, você precisará de algumas ferramentas.
+
+3. Instale o [git](https://git-scm.com/downloads) para o seu sistema operacional.
+
+-   Para começar com o git, visite [Começando com Git](https://docs.github.com/en/get-started/getting-started-with-git).
+
+-   Opcional: Se você quiser uma ferramenta gráfica para interagir com o GitHub, instale o [GitHub-Desktop](https://desktop.github.com/download/).
+
+> O GitHub Desktop pode ser mais fácil se você não estiver acostumado com a linha de comando, mas não é para todo mundo.
+
+-   Para começar com o GitHub Desktop, visite [Começando com o GitHub Desktop](https://docs.github.com/en/desktop/overview/getting-started-with-github-desktop).
+
+-   Se você quiser contribuir com código, instale o Rust em [rust-lang.org](https://www.rust-lang.org/).
+
+-   Se você deseja contribuir para a documentação, instale o [NodeJS](https://nodejs.org/en).
+
+### Decompilando o código do Minecraft
+
+Ao trabalhar no Pumpkin, nós dependemos muito do cliente oficial do Minecraft e utilizamos a lógica existente do servidor. Frequentemente, nos referimos ao código oficial do Minecraft.
+A maneira mais fácil de decompilar o Minecraft é utilizando o Fabric Yarn. Certifique-se de ter o Gradle instalado antes de executar os seguintes comandos:
+
+```
+git clone https://github.com/FabricMC/yarn.git
+cd yarn
+./gradlew decompileVineflower
+```
+
+Após a decompilação, você pode encontrar o código-fonte localizado em `build/namedSrc`.
+
+### Informações Adicionais
+
+Incentivamos você a comentar sobre problemas e pull requests existentes para compartilhar suas ideias e fornecer feedback.
+
+Fique à vontade para fazer perguntas no rastreador de problemas ou entrar em contato com os mantenedores do projeto caso precise de ajuda.
+
+Antes de enviar uma grande contribuição, considere abrir um problema ou discussão, ou conversar conosco no nosso Discord para discutir sua abordagem.

--- a/docs/pt/developer/introduction.md
+++ b/docs/pt/developer/introduction.md
@@ -1,0 +1,9 @@
+### Introdução
+
+Bem-vindo à Documentação do Pumpkin!
+
+Seja você um desenvolvedor interno do Pumpkin ou esteja trabalhando em um plugin do Pumpkin, esta documentação é o seu recurso para tudo relacionado ao Pumpkin.
+
+#### Desenvolvimento de Plugins
+
+Para uma estrutura de documentação mais organizada, a documentação sobre desenvolvimento de plugins foi movida para uma [categoria separada](/plugin-dev/introduction).

--- a/docs/pt/developer/mobile.md
+++ b/docs/pt/developer/mobile.md
@@ -1,0 +1,81 @@
+# Desenvolvimento do Pumpkin no Mobile
+
+Se você é um usuário móvel e deseja editar o código-fonte, você consegue fazer isso!  
+(Esta página foi escrita no Android usando o Helix.)
+
+Primeiro de tudo, precisamos de um aplicativo de terminal.  
+Recomendamos o [Termux](https://github.com/termux/termux-app/releases) porque é estável e open source.  
+Baixe o arquivo apk necessário para a arquitetura do seu dispositivo e instale o Termux.
+
+Após isso, você precisará rodar alguns comandos. Usamos o Helix pela sua simplicidade.
+
+```bash
+  pkg update && pkg upgrade
+  pkg install build-essential git rust rust-analyzer taplo helix helix-grammar nodejs
+```
+
+Se você quiser contribuir, precisará instalar o software do GitHub.
+
+```bash
+  pkg install gh
+```
+
+Também recomendamos instalar o fish shell porque ele é mais amigável do que o bash.
+
+```bash
+  pkg install fish
+  chsh -s fish
+```
+
+Agora que você instalou as ferramentas básicas, precisamos fazer algumas configurações.  
+Se você quiser contribuir, precisará fazer login no GitHub.
+
+```bash
+  gh auth login
+```
+
+Também configure o git: altere o editor para o vim, edite suas credenciais, etc.
+
+Após isso, você precisa clonar o repositório do Pumpkin. (Antes disso, você pode criar um diretório de projeto com `mkdir proj`; é útil)
+
+```bash
+  git clone https://github.com/Pumpkin-MC/Pumpkin.git
+```
+
+Se você quiser contribuir, precisa fazer um fork do nosso repositório e trocar `Pumpkin-MC` pelo seu nome de usuário no GitHub.
+
+A configuração está toda feita agora! Aproveite :)
+
+# FAQ
+
+## Como usar o editor de texto?
+
+Digite `hx <caminho>`.
+
+## Como navegar pelo projeto?
+
+Você pode usar `ls`, `cd` e outros programas.  
+Também pode usar `hx <diretório>` para navegar pelo seu diretório ao iniciar.
+
+## Como posso digitar no editor?
+
+Pressione `i` se você estiver no modo normal.
+
+## COMO SAIR DO EDITOR????
+
+Pressione `esc` e depois digite `:q!` se não quiser salvar, ou `:wq` se quiser salvar.
+
+## Onde posso aprender a usar esse editor?
+
+Execute `hx --tutor` ou acesse o site oficial deles.
+
+## Por que não usar o VS Code?
+
+1. O VS Code é difícil de configurar e funciona com funcionalidades limitadas na versão web.
+2. O rust-analyzer não funciona nele. Talvez um emulador ajude com isso, mas isso pode retardar a compilação do código.
+3. Com o VS Code, é altamente desejável ter um mouse, enquanto no Helix você só precisa de um teclado.
+4. O VS Code é lento em alguns dispositivos.
+
+## Por que é tão difícil digitar?
+
+Compre um teclado bluetooth barato e veja como fica mais fácil.

--- a/docs/pt/developer/networking/authentication.md
+++ b/docs/pt/developer/networking/authentication.md
@@ -1,0 +1,57 @@
+## Autenticação
+
+### Por que a autenticação é necessária
+
+Contas offline, ou seja, contas geradas a partir do nome de usuário de um jogador sem entrar em contato com um servidor de autorização ou autenticação, podem ter qualquer nickname escolhido. Isso, sem plugins adicionais, significa que jogadores podem se passar por outros jogadores, incluindo aqueles com permissões de operador.
+
+### Servidor Offline
+
+Por padrão, `online_mode` está ativado na configuração. Isso habilita a autenticação, desabilitando contas offline. Se você deseja permitir contas offline, pode desabilitar `online_mode` no arquivo `configuration.toml`.
+
+### Como funciona a autenticação Yggdrasil
+
+1. O cliente obtém um token de autenticação e UUID do launcher.
+2. O cliente, durante o carregamento, obtém dados do servidor de autorização/autenticação usando o token de autenticação, como várias chaves de assinatura e a lista de servidores bloqueados.
+3. O cliente, ao entrar no servidor, envia uma solicitação de entrada para os servidores de autorização/autenticação. Os servidores Mojang podem negar essa solicitação se a conta estiver banida.
+4. O cliente envia sua identificação para o servidor em um pacote.
+5. O servidor, com base nessa identificação, envia uma solicitação `hasJoined` para os servidores de autorização/autenticação. Se for bem-sucedido, ele obtém as informações do jogador, como a skin.
+
+### Servidor de Autenticação Personalizado
+
+Pumpkin suporta servidores de autenticação personalizados. Você pode substituir a URL de autenticação no arquivo `features.toml`.
+
+#### Como funciona a autenticação no Pumpkin
+
+1. **Requisição GET:** Pumpkin envia uma requisição GET para a URL de autenticação especificada.
+2. **Código de status 200:** Se a autenticação for bem-sucedida, o servidor responde com o código de status 200.
+3. **Parse do Perfil de Jogo em JSON:** O Pumpkin analisa o perfil de jogo em JSON retornado na resposta.
+
+#### Perfil de Jogo
+
+```rust
+struct GameProfile {
+    id: UUID,
+    name: String,
+    properties: Vec<Property>,
+    profile_actions: Option<Vec<ProfileAction>>, // Opcional, presente apenas quando ações são aplicadas
+}
+```
+
+##### Propriedade
+
+```rust
+struct Property {
+    name: String,
+    value: String, // Codificado em Base64
+    signature: Option<String>, // Opcional, codificado em Base64
+}
+```
+
+##### Ação de Perfil
+
+```rust
+enum ProfileAction {
+    FORCED_NAME_CHANGE,
+    USING_BANNED_SKIN,
+}
+```

--- a/docs/pt/developer/networking/networking.md
+++ b/docs/pt/developer/networking/networking.md
@@ -1,0 +1,241 @@
+### Rede (Networking)
+
+A maior parte do código de rede do Pumpkin pode ser encontrada na crate [pumpkin-protocol](https://github.com/Pumpkin-MC/Pumpkin/tree/master/pumpkin-protocol).
+
+Serverbound: Cliente→Servidor
+
+Clientbound: Servidor→Cliente
+
+### Estrutura
+
+Os pacotes no protocolo Pumpkin são organizados por funcionalidade e estado.
+
+`server`: Contém definições para pacotes serverbound.
+
+`client`: Contém definições para pacotes clientbound.
+
+### Estados
+
+**Handshake**: Sempre o primeiro pacote enviado pelo cliente. Isso também determina o próximo estado, geralmente indicando se o jogador deseja realizar uma solicitação de status, entrar no servidor ou ser transferido.
+
+**Status**: Indica que o cliente deseja ver uma resposta de status (MOTD).
+
+**Login**: A sequência de login. Indica que o cliente deseja entrar no servidor.
+
+**Config**: Uma sequência de pacotes de configuração que são principalmente enviados do servidor para o cliente (recursos, pacotes de recursos, links do servidor, etc.).
+
+**Play**: O estado final, que indica que o jogador está pronto para entrar, também é usado para lidar com todos os outros pacotes de gameplay.
+
+### Protocolo Minecraft
+
+Você pode encontrar todos os pacotes do Minecraft Java em [Minecraft Wiki](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol). Lá você também pode ver em qual [estado](#estados) eles estão. Você também pode ver todas as informações que os pacotes possuem, as quais podemos ler ou escrever, dependendo se são serverbound ou clientbound.
+
+### Adicionando um Pacote
+
+1. Adicionar um pacote é fácil. Primeiro, derive:
+
+```rust
+// Para pacotes clientbound:
+#[derive(Serialize)]
+
+// Para pacotes serverbound:
+#[derive(Deserialize)]
+```
+
+2. Em seguida, você deve deixar claro que sua struct representa um pacote. Isso automaticamente obterá o ID do pacote do arquivo JSON de pacotes.
+
+```rust
+// Para pacotes clientbound:
+#[client_packet("play:disconnect")]
+
+// Para pacotes serverbound:
+#[server_packet("login:move_player_pos")]
+```
+
+3. Agora você pode criar a `struct`.
+
+> [!IMPORTANT] IMPORTANTE
+> Por favor, comece o nome do pacote com "C" ou "S" para "Clientbound" ou "Serverbound".
+> Além disso, se for um pacote que pode ser enviado em múltiplos [estados](#estados), adicione o estado ao nome. Por exemplo, existem 3 pacotes de desconexão diferentes.
+>
+> -   `CLoginDisconnect`
+> -   `CConfigDisconnect`
+> -   `CPlayDisconnect`
+
+Crie campos dentro da sua estrutura de pacote para representar os dados que serão enviados.
+
+> [!IMPORTANT] IMPORTANTE
+> Use nomes de campos descritivos e tipos de dados apropriados.
+
+Exemplos:
+
+```rust
+pub struct CPlayDisconnect {
+    reason: TextComponent,
+    // mais campos...
+}
+
+pub struct SPlayerPosition {
+    pub x: f64,
+    pub feet_y: f64,
+    pub z: f64,
+    pub ground: bool,
+}
+```
+
+4. (Apenas pacotes clientbound) Implemente uma função `new` para que possamos realmente criá-los inserindo os valores.
+
+```rust
+impl CPlayDisconnect {
+    pub fn new(reason: TextComponent) -> Self {
+        Self { reason }
+    }
+}
+```
+
+5. No final, tudo deve se juntar.
+
+```rust
+#[derive(Serialize)]
+#[client_packet("play:disconnect")]
+pub struct CPlayDisconnect {
+    reason: TextComponent,
+}
+
+impl CPlayDisconnect {
+    pub fn new(reason: TextComponent) -> Self {
+        Self { reason }
+    }
+}
+
+#[derive(Deserialize)]
+#[server_packet("login:move_player_pos")]
+pub struct SPlayerPosition {
+    pub x: f64,
+    pub feet_y: f64,
+    pub z: f64,
+    pub ground: bool,
+}
+```
+
+6. Você também pode serializar/deserializar o pacote manualmente, o que pode ser útil se o pacote for mais complexo.
+
+```diff
+-#[derive(Serialize)]
+
++ impl ClientPacket for CPlayDisconnect {
++    fn write(&self, bytebuf: &mut BytesMut) {
++       bytebuf.put_slice(&self.reason.encode());
++    }
+
+-#[derive(Deserialize)]
+
++ impl ServerPacket for SPlayerPosition {
++    fn read(bytebuf: &mut Bytes) -> Result<Self, ReadingError> {
++       Ok(Self {
++           x: bytebuf.try_get_f64()?,
++           feet_y: bytebuf.try_get_f64()?,
++           z: bytebuf.try_get_f64()?,
++           ground: bytebuf.try_get_bool()?,
++       })
++    }
+```
+
+7. Agora você pode enviar o pacote clientbound (veja [Enviando Pacotes](#enviando-pacotes)) ou ouvir o pacote serverbound (veja [Recebendo Pacotes](#recebendo-pacotes)).
+
+### Cliente
+
+Pumpkin categoriza `Client`s e `Player`s separadamente. Tudo o que não está no estado de jogo é um simples `Client`. Aqui estão as diferenças:
+
+**Client**
+
+-   Só pode estar nos estados: Status, Login, Transfer, Config
+-   Não é uma entidade viva
+-   Consome poucos recursos
+
+**Player**
+
+-   Só pode estar no estado Play
+-   É uma entidade viva no mundo
+-   Possui mais dados e consome mais recursos
+
+#### Enviando Pacotes
+
+Exemplo:
+
+```rust
+// Funciona apenas no estado Status
+client.send_packet(&CStatusResponse::new("{ description: "A Description"}"));
+```
+
+#### Recebendo Pacotes
+
+Para `Client`s:
+`src/client/mod.rs`
+
+```diff
+// Coloque o pacote no estado correto
+ fn handle_mystate_packet(
+  &self,
+    server: &Arc<Server>,
+    packet: &mut RawPacket,
+) -> Result<(), ReadingError> {
+    let bytebuf = &mut packet.bytebuf;
+    match packet.id.0 {
+        SStatusRequest::PACKET_ID => {
+                self.handle_status_request(server, SStatusRequest::read(bytebuf)?)
+                    .await;
+            }
++            MyPacket::PACKET_ID => {
++                self.handle_my_packet(MyPacket::read(bytebuf)?)
++                    .await;
+            }
+            _ => {
+            log::error!(
+                "Falha ao lidar com o pacote id {} enquanto no estado ...",
+                packet.id.0
+            );
+            }
+    };
+    Ok(())
+}
+```
+
+Para `Player`s:
+`src/entity/player.rs`
+
+```diff
+// Players só têm o estado Play
+ fn handle_play_packet(
+  &self,
+    server: &Arc<Server>,
+    packet: &mut RawPacket,
+) -> Result<(), ReadingError> {
+    let bytebuf = &mut packet.bytebuf;
+    match packet.id.0 {
+        SChatMessage::PACKET_ID => {
+            self.handle_chat_message(SChatMessage::read(bytebuf)?).await;
+        }
+       MyPacket::PACKET_ID => {
++           self.handle_mypacket(server, MyPacket::read(bytebuf)?).await;
+        }
+        _ => {
+            log::error!(
+                "Falha ao lidar com o pacote id {} enquanto no estado ...",
+                packet.id.0
+            );
+        }
+    };
+    Ok(())
+}
+```
+
+### Compressão
+
+Os pacotes do Minecraft **podem** usar compressão ZLib para decodificação/encodificação. Normalmente, existe um limite quando a compressão é aplicada; isso afeta principalmente pacotes de chunks.
+
+### Portabilidade
+
+Para portar para uma nova versão do Minecraft, você pode comparar as diferenças no protocolo na [referência de protocolo minecraft.wiki](https://minecraft.wiki/w/Java_Edition_protocol).
+
+Além disso, altere o `CURRENT_MC_PROTOCOL` em `src/lib.rs`.

--- a/docs/pt/developer/networking/rcon.md
+++ b/docs/pt/developer/networking/rcon.md
@@ -1,0 +1,64 @@
+### RCON
+
+### O que é RCON
+
+RCON (Console Remoto) é um protocolo criado pela Valve para permitir que administradores controlem e gerenciem servidores de jogos remotamente. Ele oferece uma maneira de executar comandos em um servidor de um local diferente, como um celular ou um computador separado.
+
+### Por que usar RCON
+
+-   **Conveniência:** Gerencie seu servidor de qualquer lugar com uma conexão à internet.
+-   **Flexibilidade:** Execute comandos sem precisar estar fisicamente presente no local do servidor.
+-   **Eficiência:** Automatize tarefas e torne o gerenciamento do servidor mais ágil.
+
+### SSH vs RCON
+
+**SSH**
+
+-   Oferece forte criptografia para proteger os dados transmitidos entre o cliente e o servidor.
+-   Principalmente projetado para login remoto seguro e execução de comandos em uma máquina remota.
+-   Comumente usado para gerenciar sistemas Linux/Unix, configurar redes e executar scripts.
+-   Fornece um ambiente de shell, permitindo que você execute diversos comandos e interaja com o sistema remoto.
+
+**RCON**
+
+-   Especificamente projetado para administração remota de servidores de jogos, permitindo que você controle e gerencie as configurações e operações do servidor.
+-   Geralmente menos seguro que o SSH, pois muitas vezes depende de senhas em texto simples.
+-   Principalmente utilizado por administradores de servidores de jogos para gerenciar servidores de jogos.
+-   Tem um conjunto limitado de comandos, específicos do jogo.
+
+### Pacotes
+
+RCON é um protocolo muito simples com poucos pacotes. Veja como um pacote RCON se parece:
+
+| Campo | Descrição                                                   |
+| ----- | ----------------------------------------------------------- |
+| ID    | Usado para indicar se a autenticação falhou ou teve sucesso |
+| Tipo  | Identifica o tipo de pacote                                 |
+| Corpo | Uma mensagem (String), por exemplo, um comando ou uma senha |
+
+#### Pacotes Serverbound <sub><sub>(Cliente→Servidor)</sub></sub>
+
+| Tipo | Pacote      |
+| ---- | ----------- |
+| 2    | Auth        |
+| 3    | ExecCommand |
+
+#### Pacotes Clientbound <sub><sub>(Servidor→Cliente)</sub></sub>
+
+| Tipo | Pacote       |
+| ---- | ------------ |
+| 2    | AuthResponse |
+| 0    | Output       |
+
+### Como o RCON Funciona
+
+1. **Autenticação:**
+
+    - O cliente RCON envia um pacote de autenticação com a senha desejada.
+    - O servidor verifica a senha e responde com um pacote de resposta de autenticação.
+    - Se bem-sucedido, o pacote de resposta inclui o mesmo ID enviado pelo cliente. Se não for bem-sucedido, o ID é -1.
+
+2. **Execução de Comandos:**
+
+    - O cliente autenticado pode agora enviar pacotes de execução de comandos, com cada pacote contendo o comando a ser executado.
+    - O servidor processa o comando e envia de volta um pacote de saída contendo o resultado ou qualquer mensagem de erro.

--- a/docs/pt/developer/world.md
+++ b/docs/pt/developer/world.md
@@ -1,0 +1,80 @@
+### Formatos de Mundo
+
+#### Formato de Arquivo de Região
+
+Do Minecraft Beta 1.3 até o Release 1.2, era utilizado um formato de Minecraft conhecido como "Formato de Arquivo de Região".
+
+Os arquivos armazenados nesse formato são arquivos `.mcr`, cada um armazenando um grupo de 32x32 chunks, chamado de região.
+
+Mais detalhes podem ser encontrados na [Minecraft Wiki](https://minecraft.wiki/w/Region_file_format).
+
+#### Formato de Arquivo Anvil
+
+Substituindo o Formato de Arquivo de Região após o Minecraft Release 1.2, este é o formato de arquivo usado para armazenar mundos modernos do Minecraft: Java Edition.
+
+Os arquivos armazenados nesse formato são arquivos `.mca`. Embora utilize a mesma lógica de regiões, houve várias mudanças. As mudanças notáveis incluem o aumento do limite de altura para 256, depois para 320, assim como um maior número de IDs de blocos.
+
+Mais detalhes podem ser encontrados na [Minecraft Wiki](https://minecraft.wiki/w/Anvil_file_format).
+
+#### Formato de Arquivo Linear
+
+Existe um formato de arquivo mais moderno conhecido como Formato de Arquivo de Região Linear. Ele economiza espaço em disco e usa a biblioteca zstd em vez de zlib. Isso é benéfico, pois o zlib é extremamente antigo e desatualizado.
+
+Os arquivos armazenados nesse formato são arquivos `.linear`, e eles economizam cerca de 50% de espaço em disco no Overworld e no Nether, e 95% no End.
+
+Mais detalhes podem ser encontrados na página do GitHub para [LinearRegionFileFormatTools](https://github.com/xymb-endcrystalme/LinearRegionFileFormatTools).
+
+#### Formato de Arquivo Slime
+
+Desenvolvido pela Hypixel para corrigir muitos dos problemas do formato de arquivo Anvil, o Slime também substitui o zlib e economiza espaço em comparação com o Anvil. Ele salva o mundo inteiro em um único arquivo de salvamento e permite que esse arquivo seja carregado em várias instâncias.
+
+Os arquivos armazenados nesse formato são arquivos `.slime`.
+
+Mais detalhes podem ser encontrados na página do GitHub para [Slime World Manager](https://github.com/cijaaimee/Slime-World-Manager#:~:text=Slime%20World%20Manager%20is%20a,worlds%20faster%20and%20save%20space.), assim como no [Dev Blog #5](https://hypixel.net/threads/dev-blog-5-storing-your-skyblock-island.2190753/) da Hypixel.
+
+#### Formato de Arquivo Schematic
+
+Diferentemente dos outros formatos de arquivo listados, o Formato de Arquivo Schematic não é usado para armazenar mundos do Minecraft, mas sim dentro de programas de terceiros, como MCEdit, WorldEdit e Schematica.
+
+Os arquivos armazenados nesse formato são arquivos `.schematic`, e são armazenados no formato NBT.
+
+Mais detalhes podem ser encontrados na [Minecraft Wiki](https://minecraft.wiki/w/Schematic_file_format).
+
+### Geração de Mundo
+
+Quando o servidor está iniciando, ele verifica se há um salvamento presente, também conhecido como "mundo".
+
+Pumpkin então chama a geração do mundo:
+
+#### Salvamento Presente
+
+`AnvilChunkReader` é chamado para processar os arquivos de região para o salvamento dado.
+
+-   Como mencionado acima, os arquivos de região armazenam chunks de 32x32.
+    > Cada arquivo de região é nomeado de acordo com as coordenadas de onde ele está no mundo.
+
+> r.{}.{}.mca
+
+-   A tabela de localização é lida a partir do arquivo de salvamento, representando as coordenadas do chunk.
+-   A tabela de timestamp é lida a partir do arquivo de salvamento, representando a última vez que o chunk foi modificado.
+
+#### Sem Salvamento Presente
+
+A semente do mundo é definida como "0". No futuro, ela será definida para o valor na configuração "básica".
+
+`PlainsGenerator` é chamado, já que até agora `Plains` é o único bioma implementado.
+
+-   `PerlinTerrainGenerator` é chamado para definir a altura do chunk.
+-   A altura da pedra é definida 5 blocos abaixo da altura do chunk.
+-   A altura da terra é definida 2 blocos abaixo da altura do chunk.
+-   Blocos de grama aparecem no topo da terra.
+-   Bedrock é definido em y = -64.
+-   Flores e grama curta são espalhadas aleatoriamente.
+
+`SuperflatGenerator` também está disponível, mas não é atualmente chamável.
+
+-   Bedrocks é definido em y = -64.
+-   A terra é definida dois blocos para cima.
+-   Os blocos de grama são definidos um bloco a mais para cima.
+
+Os blocos podem ser colocados e quebrados, mas as mudanças não podem ser salvas em nenhum formato de mundo. Mundos do formato Anvil são atualmente apenas leitura.

--- a/docs/pt/index.md
+++ b/docs/pt/index.md
@@ -1,0 +1,34 @@
+---
+# https://vitepress.dev/reference/default-theme-home-page
+layout: home
+
+hero:
+    name: "Pumpkin"
+    text: "Servidor de Minecraft"
+    tagline: Possibilitando a todos hospedar servidores de Minecraft rápidos e eficientes.
+    image:
+        src: /assets/icon.png
+        alt: Pumpkin
+    actions:
+        - theme: brand
+          text: Primeiros Passos
+          link: /pt/about/quick-start
+        - theme: alt
+          text: Configuração
+          link: /pt/config/introduction
+        - theme: alt
+          text: Desenvolvedores
+          link: /pt/developer/introduction
+
+features:
+    # Need to add the svg here instead of using src because then it won't have the box around it
+    - icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="-20 -20 146 146"><g transform="translate(53 53)"><path stroke="#000" stroke-linejoin="round" d="M-8.5-14.5h13c8 0 8 8 0 8h-13Zm-31 37h40v-11h-9v-8h10c11 0 5 19 14 19h25v-19h-6v2c0 8-9 7-10 2s-5-9-6-9c15-8 6-24-6-24h-47v11h10v26h-15Z"/><g mask="url(#a)"><circle r="43" fill="none" stroke="#000" stroke-width="9"/><path id="b" stroke="#000" stroke-linejoin="round" stroke-width="3" d="m46 3 5-3-5-3z"/><use href="#b" transform="rotate(11.3)"/><use href="#b" transform="rotate(22.5)"/><use href="#b" transform="rotate(33.8)"/><use href="#b" transform="rotate(45)"/><use href="#b" transform="rotate(56.3)"/><use href="#b" transform="rotate(67.5)"/><use href="#b" transform="rotate(78.8)"/><use href="#b" transform="rotate(90)"/><use href="#b" transform="rotate(101.3)"/><use href="#b" transform="rotate(112.5)"/><use href="#b" transform="rotate(123.8)"/><use href="#b" transform="rotate(135)"/><use href="#b" transform="rotate(146.3)"/><use href="#b" transform="rotate(157.5)"/><use href="#b" transform="rotate(168.8)"/><use href="#b" transform="rotate(180)"/><use href="#b" transform="rotate(191.3)"/><use href="#b" transform="rotate(202.5)"/><use href="#b" transform="rotate(213.8)"/><use href="#b" transform="rotate(225)"/><use href="#b" transform="rotate(236.3)"/><use href="#b" transform="rotate(247.5)"/><use href="#b" transform="rotate(258.8)"/><use href="#b" transform="rotate(270)"/><use href="#b" transform="rotate(281.3)"/><use href="#b" transform="rotate(292.5)"/><use href="#b" transform="rotate(303.8)"/><use href="#b" transform="rotate(315)"/><use href="#b" transform="rotate(326.3)"/><use href="#b" transform="rotate(337.5)"/><use href="#b" transform="rotate(348.8)"/><path id="c" stroke="#000" stroke-linejoin="round" stroke-width="6" d="m-7-42 7 7 7-7z"/><use href="#c" transform="rotate(72)"/><use href="#c" transform="rotate(144)"/><use href="#c" transform="rotate(216)"/><use href="#c" transform="rotate(288)"/></g><mask id="a"><path fill="#fff" d="M-60-60H60V60H-60z"/><circle id="d" cy="-40" r="3"/><use href="#d" transform="rotate(72)"/><use href="#d" transform="rotate(144)"/><use href="#d" transform="rotate(216)"/><use href="#d" transform="rotate(288)"/></mask></g></svg>
+      title: Escrito em Rust
+      details: Pumpkin é escrito 100% em Rust, garantindo segurança de memória e desempenho incomparável.
+    - icon: 📋
+      title: Funcionalidade completa
+      details: Com todos os recursos vanila suportados, você não terá problemas.
+    - icon: ⚙️
+      title: Flexível
+      details: Altamente configurável, com a capacidade de desabilitar recursos desnecessários.
+---

--- a/docs/pt/plugin-dev/introduction.md
+++ b/docs/pt/plugin-dev/introduction.md
@@ -1,0 +1,10 @@
+# Desenvolvimento de Plugins Pumpkin
+
+::: warning ATENÇÃO
+A API de Plugins Pumpkin ainda está em um estágio inicial de desenvolvimento e pode mudar a qualquer momento.
+Se você encontrar algum problema, por favor, entre em contato em [nosso servidor no Discord](https://discord.gg/aaNuD6rFEe).
+:::
+
+Os Plugins Pumpkin se integram ao software do servidor de maneira muito profunda, permitindo muitas coisas que não seriam possíveis em outros softwares de servidor.
+
+A API de Plugins Pumpkin se inspira na API de plugins do Spigot/Bukkit em diversos aspectos, então, se você tem experiência prévia com os mesmos e possui experiência com desenvolvimento em Rust, você terá uma experiência relativamente fácil ao escrever plugins para o Pumpkin. :smile:

--- a/docs/pt/plugin-dev/plugin-template/basic-logic.md
+++ b/docs/pt/plugin-dev/plugin-template/basic-logic.md
@@ -1,0 +1,170 @@
+# Escrevendo a Lógica Básica
+
+## Base do Plugin
+
+Mesmo em um plugin básico, há muita coisa acontecendo nos bastidores, então, para simplificar bastante o desenvolvimento de plugins, usaremos o crate `pumpkin-api-macros` para criar um plugin básico vazio.
+
+:::code-group
+
+```rs:line-numbers [lib.rs]
+use pumpkin_api_macros::plugin_impl;
+
+#[plugin_impl]
+pub struct MyPlugin {}
+
+impl MyPlugin {
+    pub fn new() -> Self {
+        MyPlugin {}
+    }
+}
+
+impl Default for MyPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+```
+
+:::
+
+Isso criará um plugin vazio e implementará todos os métodos necessários para que ele seja carregado pelo Pumpkin.
+
+Agora podemos tentar compilar nosso plugin pela primeira vez. Para isso, execute o seguinte comando na pasta do seu projeto:
+
+```bash
+cargo build --release
+```
+
+::: tip AVISO
+Se você estiver usando o Windows, você **tem** que usar a flag `--release`, caso contrário, terá problemas. Se você estiver em outra plataforma, não precisa usá-la caso queira economizar tempo de compilação.
+:::
+A compilação inicial levará um pouco de tempo, mas não se preocupe, as compilações seguintes serão mais rápidas.
+
+Se tudo correr bem, você deverá ver uma mensagem como esta:
+
+```log
+╰─ cargo build --release
+   Compiling hello-pumpkin v0.1.0 (/home/vypal/Dokumenty/GitHub/hello-pumpkin)
+    Finished `release` profile [optimized] target(s) in 0.68s
+```
+
+Agora você pode ir para a pasta `./target/release` (ou `./target/debug` se não usou `--release`) e localizar o binário do seu plugin.
+
+Dependendo do seu sistema operacional, o arquivo terá um dos três nomes possíveis:
+
+-   Para Windows: `hello-pumpkin.dll`
+-   Para MacOS: `libhello-pumpkin.dylib`
+-   Para Linux: `libhello-pumpkin.so`
+
+::: info NOTA
+Se você usou um nome de projeto diferente no arquivo `Cargo.toml`, procure o arquivo que contenha o nome do seu projeto.
+:::
+
+Você pode renomear este arquivo como quiser, mas deve manter a extensão do arquivo (`.dll`, `.dylib` ou `.so`) a mesma.
+
+## Testando o Plugin
+
+Agora que temos o binário do plugin, podemos testá-lo no servidor Pumpkin. Instalar um plugin é tão simples quanto colocar o binário do plugin que acabamos de construir na pasta `plugins/` do seu servidor Pumpkin!
+
+Graças à macro `#[plugin_impl]`, o plugin terá seus detalhes (como nome, autores, versão e descrição) incorporados ao binário para que o servidor possa lê-los.
+
+Quando você iniciar o servidor e executar o comando `/plugins`, deverá ver uma resposta como esta:
+
+```
+Há 1 plugin carregado:
+hello-pumpkin
+```
+
+## Métodos Básicos
+
+O servidor Pumpkin atualmente usa dois "métodos" para informar ao plugin sobre seu estado. Esses métodos são `on_load` e `on_unload`.
+
+Esses métodos não precisam ser implementados, mas você normalmente implementará pelo menos o método `on_load`. Nesse método, você tem acesso a um objeto `Context`, que pode fornecer ao plugin acesso a informações sobre o servidor, além de permitir que o plugin registre gerenciadores de comandos e eventos.
+
+Para facilitar a implementação desses métodos, há outra macro fornecida pelo crate `pumpkin-api-macros`.
+:::code-group
+
+```rs [lib.rs]
+use pumpkin_api_macros::{plugin_impl, plugin_method}; // [!code ++:2]
+use pumpkin::plugin::Context;
+use pumpkin_api_macros::plugin_impl; // [!code --]
+
+#[plugin_method] // [!code ++:4]
+async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+    Ok(())
+}
+
+#[plugin_impl]
+pub struct MyPlugin {}
+
+impl MyPlugin {
+    pub fn new() -> Self {
+        MyPlugin {}
+    }
+}
+
+impl Default for MyPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+```
+
+:::
+
+::: warning IMPORTANTE
+É importante que você defina qualquer método do plugin antes do bloco `#[plugin_impl]`.
+:::
+
+Este método recebe uma referência mutável ao objeto do plugin (neste caso, a struct `MyPlugin`), que pode ser usada para inicializar quaisquer dados armazenados na struct principal do plugin, e uma referência ao objeto `Context`. Esse objeto é especificamente construído para este plugin com base nos metadados do plugin.
+
+### Métodos implementados no objeto `Context`:
+
+```rs
+fn get_data_folder() -> String
+```
+
+Retorna o caminho para a pasta dedicada a este plugin, que deve ser usada para armazenamento de dados persistentes.
+
+```rs
+async fn get_player_by_name(player_name: String) -> Option<Arc<Player>>
+```
+
+Se um jogador com o nome `player_name` for encontrado (ele precisa estar online no momento), esta função retornará uma referência a ele.
+
+```rs
+async fn register_command(tree: CommandTree, permission: PermissionLvl)
+```
+
+Registra um novo gerenciador de comandos, com um nível mínimo de permissão exigido.
+
+```rs
+async fn register_event(handler: Arc<H>, priority: EventPriority, blocking: bool)
+```
+
+Registra um novo gerenciador de eventos com uma prioridade definida e se é bloqueante ou não.
+Aliás, `handler` é `Arc<T>`, o que significa que você pode implementar vários eventos em um único gerenciador e depois registrá-lo.
+
+## Método Básico `on_load`
+
+Por enquanto, vamos implementar apenas um método `on_load` bem básico para conseguirmos ver que o plugin está funcionando.
+
+Aqui vamos configurar o logger interno do Pumpkin e exibir "Hello, Pumpkin!" para que possamos ver nosso plugin em ação.
+
+Adicione isso ao método `on_load`:
+:::code-group
+
+```rs [lib.rs]
+#[plugin_method]
+async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+    pumpkin::init_log!(); // [!code ++:3]
+
+    log::info!("Hello, Pumpkin!");
+
+    Ok(())
+}
+```
+
+:::
+
+Se compilarmos o plugin novamente e iniciarmos o servidor, agora você deverá ver "Hello, Pumpkin!" em algum lugar no log.

--- a/docs/pt/plugin-dev/plugin-template/creating-project.md
+++ b/docs/pt/plugin-dev/plugin-template/creating-project.md
@@ -1,0 +1,83 @@
+# Criando um Novo Projeto
+
+Plugins Pumpkin utilizam o sistema de build [Cargo](https://doc.rust-lang.org/book/ch01-03-hello-cargo.html).
+
+O código completo para este plugin pode ser encontrado como um [modelo no GitHub](https://github.com/vyPal/Hello-Pumpkin).
+
+## Inicializando um novo crate
+
+Primeiro, precisamos criar uma nova pasta para o projeto. Você pode fazer isso executando o seguinte comando na pasta que você criou:
+
+```bash
+cargo new <nome-do-projeto> --lib
+```
+
+Isso criará uma pasta com alguns arquivos dentro. A estrutura da pasta deverá ser parecida com esta:
+
+```
+├── Cargo.toml
+└── src
+    └── lib.rs
+```
+
+## Configurando o crate
+
+Como os plugins Pumpkin são carregados em tempo de execução como bibliotecas dinâmicas, precisamos dizer ao Cargo para construir esse crate dessa forma.
+:::code-group
+
+```toml [Cargo.toml]
+[package]
+name = "hello-pumpkin"
+version = "0.1.0"
+edition = "2021"
+
+[lib] // [!code ++:3]
+crate-type = ["cdylib"]
+
+[dependencies]
+```
+
+:::
+
+Em seguida, precisamos adicionar algumas dependências básicas. Como o Pumpkin ainda está em desenvolvimento inicial, os crates internos não estão publicados no crates.io, então precisamos dizer ao Cargo para baixar as dependências diretamente do GitHub.
+:::code-group
+
+```toml [Cargo.toml]
+[package]
+name = "hello-pumpkin"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+// [!code ++:13]
+# Este é um crate base com a maioria das definições de tipos de alto nível
+pumpkin = { git = "https://github.com/Pumpkin-MC/Pumpkin.git", branch = "master", package = "pumpkin" }
+# Outras utilidades usadas pelo Pumpkin (por exemplo, TextComponent, Vectors...)
+pumpkin-util = { git = "https://github.com/Pumpkin-MC/Pumpkin.git", branch = "master", package = "pumpkin-util" }
+# Macros para facilitar o desenvolvimento de plugins
+pumpkin-api-macros = { git = "https://github.com/Pumpkin-MC/Pumpkin.git", branch = "master", package = "pumpkin-api-macros" }
+
+# Uma utilidade permitindo que plugins funcionem de maneira assíncrona
+async-trait = "0.1"
+# Um runtime assíncrono em Rust
+tokio = "1.42"
+# Logging
+log = "0.4"
+```
+
+:::
+
+Para melhorar o desempenho e reduzir o tamanho dos arquivos, recomendamos habilitar a Otimização em Tempo de Link (LTO).  
+Esteja ciente de que isso aumentará o tempo de compilação.
+:::code-group
+
+```toml [Cargo.toml]
+[profile.release] // [!code ++:2]
+lto = true
+```
+
+:::
+<small>Habilita LTO apenas para builds release.</small>

--- a/docs/pt/plugin-dev/plugin-template/introduction.md
+++ b/docs/pt/plugin-dev/plugin-template/introduction.md
@@ -1,0 +1,11 @@
+# Escrevendo um Plugin de Exemplo
+
+Este tutorial irá guiá-lo na criação de um novo plugin.
+
+Este tutorial assume que você tem alguma experiência com Rust e linha de comando.
+
+Tópicos descritos neste tutorial:
+
+-   Modificando a mensagem de entrada
+-   Criando um comando de pedra-papel-tesoura (em breve)
+-   Salvando dados do plugin em diretório (em breve)

--- a/docs/pt/plugin-dev/plugin-template/join-event.md
+++ b/docs/pt/plugin-dev/plugin-template/join-event.md
@@ -1,0 +1,105 @@
+# Escrevendo um Gerenciador de Evento
+
+Gerenciadores de eventos são uma das funções principais dos plugins. Eles permitem que um plugin acesse o funcionamento interno do servidor e altere seu comportamento para realizar alguma outra ação. Como exemplo simples, vamos implementar um manipulador para o evento `player_join`.
+
+O sistema de eventos do Pumpkin tenta imitar o sistema de eventos do Bukkit/Spigot, para que desenvolvedores que vêm de lá tenham uma experiência mais fácil ao aprender o Pumpkin. No entanto, Rust tem concepções e regras diferentes, por isso nem tudo é como no Bukkit/Spigot. Rust não tem herança; em vez disso, ele só tem composição.
+
+O sistema de eventos usa traits para gerenciar dinamicamente alguns eventos: `Event`, `Cancellable`, `PlayerEvent` e etc. `Cancellable` também pode ser um evento, porque é uma trait. (TODO: verificar isso)
+
+## Implementando o Evento de Entrada
+
+Gerenciadores de eventos individuais são apenas structs que implementam a trait `EventHandler<T>` (onde `T` é uma implementação específica de evento).
+
+### O que são eventos bloqueantes?
+
+O sistema de eventos do Pumpkin diferencia dois tipos de eventos: bloqueantes e não bloqueantes. Cada um tem seus benefícios:
+
+#### Eventos bloqueantes
+
+```diff
+Prós:
++ Podem modificar o evento (como editar a mensagem de entrada)
++ Podem cancelar o evento
++ Têm um sistema de prioridade
+Contras:
+- São executados em sequência
+- Podem diminuir a performance do servidor se não forem bem implementados
+```
+
+#### Eventos não bloqueantes
+
+```diff
+Prós:
++ São executados simultaneamente
++ São executados depois de todos os eventos bloqueantes terminarem
++ Ainda podem fazer algumas modificações (qualquer coisa que esteja atrás de um Mutex ou RwLock)
+Contras:
+- Não podem cancelar o evento
+- Não têm sistema de prioridade
+- Oferecem menos controle sobre o evento
+```
+
+### Escrevendo um gerenciador
+
+Como nosso objetivo principal aqui é mudar a mensagem de boas-vindas que o jogador vê quando entra no servidor, vamos escolher o tipo de evento bloqueante com uma prioridade baixa.
+
+Adicione este código acima do método `on_load`:
+:::code-group
+
+```rs [lib.rs]
+use async_trait::async_trait; // [!código ++:4]
+use pumpkin_api_macros::with_runtime;
+use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler};
+use pumpkin_util::text::{color::NamedColor, TextComponent};
+
+struct MyJoinHandler; // [!código ++:12]
+
+#[with_runtime(global)]
+#[async_trait]
+impl EventHandler<PlayerJoinEvent> for MyJoinHandler {
+    async fn handle_blocking(&self, event: &mut PlayerJoinEvent) {
+        event.join_message =
+            TextComponent::text(format!("Bem-vindo, {}!", event.player.gameprofile.name))
+                .color_named(NamedColor::Green);
+    }
+}
+```
+
+:::
+
+**Explicação**:
+
+-   `struct MyJoinHandler;`: A struct para nosso gerenciador de evento.
+-   `#[with_runtime(global)]`: Pumpkin usa o runtime assíncrono tokio, que age de maneira estranha além dos limites do plugin. Embora não seja necessário neste exemplo específico, é uma boa prática envolver todos os `impl`s assíncronos que interagem com código assíncrono com essa macro.
+-   `#[async_trait]`: Rust não tem suporte completo para traits com métodos assíncronos. Então, usamos o crate `async_trait` para permitir isso.
+-   `async fn handle_blocking()`: Como escolhemos que este evento será bloqueante, é necessário implementar o método `handle_blocking()` ao invés do método `handle()`.
+
+::: warning IMPORTANTE
+É importante que a macro `#[with_runtime(global)]` esteja **acima** da macro **`#[async_trait]`**. Se estiverem na ordem oposta, a macro `#[with_runtime(global)]` pode não funcionar.
+:::
+
+### Registrando o gerenciador
+
+Agora que escrevemos o gerenciador de evento, precisamos informar ao plugin para usá-lo. Podemos fazer isso adicionando uma única linha no método `on_load`:
+
+:::code-group
+
+```rs [lib.rs]
+use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler, EventPriority}; // [!código ++]
+use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler}; // [!código --]
+
+#[plugin_method]
+async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+    pumpkin::init_log!();
+
+    log::info!("Olá, Pumpkin!");
+
+    server.register_event(Arc::new(MyJoinHandler), EventPriority::Lowest, true).await; // [!código ++]
+
+    Ok(())
+}
+```
+
+:::
+
+Agora, se compilarmos o plugin e entrarmos no servidor, devemos ver uma mensagem de boas-vindas verde com o nosso nome de usuário!

--- a/docs/pt/troubleshooting/common_issues.md
+++ b/docs/pt/troubleshooting/common_issues.md
@@ -1,0 +1,9 @@
+### Problemas Comuns
+
+1.  ### Falha ao verificar nome de usuário
+
+    **Problema:** Alguns jogadores relataram dificuldades ao logar no servidor, incluindo o erro "Falha ao verificar nome de usuário".
+
+    **Causa:** Isso está relacionado à autenticação, geralmente com a configuração `prevent_proxy_connections`.
+
+    **Solução:** Desative a opção `prevent_proxy_connections` em `features.toml`.


### PR DESCRIPTION
# Portuguese Localization

Pull request for tracking the progress of Portuguese localization of the documentation, work in progress.

## Repo Tasks:
- [x] Create a new locale file in `docs/.vitepress/` (e.g., `fr.ts` for a French translation).
- [x] Translate the content and update all links with the appropriate language code (refer to the Dutch translation for an example).
- [x] Register the new locale in `docs/.vitepress/config.ts`.
- [x] Duplicate the English documentation folder (`docs/en/`) and rename it to your language's ISO code (e.g., `en` → `pt`).
- [x] Translate all documentation files in the newly created folder.
- [x] Configure the typo check to skip the translation files in `.typos.toml`.

## Documentation Progress:

- [x] Home
- [x] About
  - [x] Introduction
  - [x] Quick Start
  - [x] Benchmarks
- [x] Configuration
  - [x] Introduction
  - [x] Basic
  - [x] Proxy
  - [x] Authentication
  - [x] Compression
  - [x] Resource Pack
  - [x] Commands
  - [x] RCON
  - [x] PVP
  - [x] Logging
  - [x] Query
  - [x] LAN Broadcast
- [x] Developers
  - [x] Contributing
  - [x] Introduction
  - [x] Networking
    - [x] Authentication
    - [x] RCON
  - [x] World
  - [x] Mobile Dev
- [x] Plugin Development
  - [x] Introduction
  - [x] Plugin Template
    - [x] Creating Project
    - [x] Basic Logic
    - [x] Join Event
- [x] Troubleshooting
  - [x] Common Issues
