### PR TITLE
fix: Use correct server parameter type for on_load plugin examples

### DIFF
--- a/docs/en/plugin-dev/plugin-template/basic-logic.md
+++ b/docs/en/plugin-dev/plugin-template/basic-logic.md
@@ -85,12 +85,14 @@ To make implementing these methods easier, there is another macro provided by th
 :::code-group
 
 ```rs [lib.rs]
-use pumpkin_api_macros::{plugin_impl, plugin_method}; // [!code ++:2]
+use std::sync::Arc; // [!code ++:4]
+
+use pumpkin_api_macros::{plugin_impl, plugin_method};
 use pumpkin::plugin::Context;
 use pumpkin_api_macros::plugin_impl; // [!code --]
 
 #[plugin_method] // [!code ++:4]
-async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
     Ok(())
 }
 
@@ -156,7 +158,7 @@ Add this to the `on_load` method:
 
 ```rs [lib.rs]
 #[plugin_method]
-async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
     pumpkin::init_log!(); // [!code ++:3]
 
     log::info!("Hello, Pumpkin!");

--- a/docs/en/plugin-dev/plugin-template/join-event.md
+++ b/docs/en/plugin-dev/plugin-template/join-event.md
@@ -100,7 +100,7 @@ use pumpkin::{
 };
 
 #[plugin_method]
-async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
     pumpkin::init_log!();
 
     log::info!("Hello, Pumpkin!");

--- a/docs/en/plugin-dev/plugin-template/rock-paper-scissors.md
+++ b/docs/en/plugin-dev/plugin-template/rock-paper-scissors.md
@@ -201,7 +201,7 @@ const NAMES: [&str; 2] = ["rps", "rockpaperscissors"]; // [!code ++:2]
 const DESCRIPTION: &str = "Play Rock Paper Scissors with the server.";
 
 #[plugin_method]
-async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
     pumpkin::init_log!();
 
     log::info!("Hello, Pumpkin!");

--- a/docs/nl/plugin-dev/plugin-template/basic-logic.md
+++ b/docs/nl/plugin-dev/plugin-template/basic-logic.md
@@ -73,12 +73,14 @@ These methods don't have to be implemented, but you will usually implement at le
 To make implementing these methods easier, there is another macro provided by the `pumpkin-api-macros` crate. 
 :::code-group
 ```rs [lib.rs]
-use pumpkin_api_macros::{plugin_impl, plugin_method}; // [!code ++:2]
+use std::sync::Arc; // [!code ++:4]
+
+use pumpkin_api_macros::{plugin_impl, plugin_method};
 use pumpkin::plugin::Context;
 use pumpkin_api_macros::plugin_impl; // [!code --]
 
 #[plugin_method] // [!code ++:4]
-async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
     Ok(())
 }
 
@@ -133,7 +135,7 @@ Add this to the `on_load` method:
 :::code-group
 ```rs [lib.rs]
 #[plugin_method]
-async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
     pumpkin::init_log!(); // [!code ++:3]
 
     log::info!("Hello, Pumpkin!");

--- a/docs/nl/plugin-dev/plugin-template/join-event.md
+++ b/docs/nl/plugin-dev/plugin-template/join-event.md
@@ -78,7 +78,7 @@ use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler, EventPrior
 use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler}; // [!code --]
 
 #[plugin_method]
-async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
     pumpkin::init_log!();
 
     log::info!("Hello, Pumpkin!");

--- a/docs/pt/plugin-dev/plugin-template/basic-logic.md
+++ b/docs/pt/plugin-dev/plugin-template/basic-logic.md
@@ -85,12 +85,14 @@ Para facilitar a implementação desses métodos, há outra macro fornecida pelo
 :::code-group
 
 ```rs [lib.rs]
-use pumpkin_api_macros::{plugin_impl, plugin_method}; // [!code ++:2]
+use std::sync::Arc; // [!code ++:4]
+
+use pumpkin_api_macros::{plugin_impl, plugin_method};
 use pumpkin::plugin::Context;
 use pumpkin_api_macros::plugin_impl; // [!code --]
 
 #[plugin_method] // [!code ++:4]
-async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
     Ok(())
 }
 
@@ -156,7 +158,7 @@ Adicione isso ao método `on_load`:
 
 ```rs [lib.rs]
 #[plugin_method]
-async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
     pumpkin::init_log!(); // [!code ++:3]
 
     log::info!("Hello, Pumpkin!");

--- a/docs/pt/plugin-dev/plugin-template/join-event.md
+++ b/docs/pt/plugin-dev/plugin-template/join-event.md
@@ -89,7 +89,7 @@ use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler, EventPrior
 use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler}; // [!código --]
 
 #[plugin_method]
-async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
     pumpkin::init_log!();
 
     log::info!("Olá, Pumpkin!");

--- a/docs/zh_cn/plugin-dev/plugin-template/basic-logic.md
+++ b/docs/zh_cn/plugin-dev/plugin-template/basic-logic.md
@@ -85,12 +85,14 @@ hello-pumpkin
 :::code-group
 
 ```rs [lib.rs]
-use pumpkin_api_macros::{plugin_impl, plugin_method}; // [!code ++:2]
+use std::sync::Arc; // [!code ++:4]
+
+use pumpkin_api_macros::{plugin_impl, plugin_method};
 use pumpkin::plugin::Context;
 use pumpkin_api_macros::plugin_impl; // [!code --]
 
 #[plugin_method] // [!code ++:4]
-async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
     Ok(())
 }
 
@@ -156,7 +158,7 @@ async fn register_event(handler: Arc<H>, priority: EventPriority, blocking: bool
 
 ```rs [lib.rs]
 #[plugin_method]
-async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
     pumpkin::init_log!(); // [!code ++:3]
 
     log::info!("Hello, Pumpkin !");

--- a/docs/zh_cn/plugin-dev/plugin-template/join-event.md
+++ b/docs/zh_cn/plugin-dev/plugin-template/join-event.md
@@ -91,7 +91,7 @@ use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler, EventPrior
 use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler}; // [!code --]
 
 #[plugin_method]
-async fn on_load(&mut self, server: &Context) -> Result<(), String> {
+async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
     pumpkin::init_log!();
 
     log::info!("你好， Pumpkin ！");


### PR DESCRIPTION
The correct parameter is `server: Arc<Context>`

Let me know if there is anything I missed