### PR TITLE
Remove `pumpkin::init_log!()` from docs

### DIFF
--- a/docs/de/plugin-dev/plugin-template/basic-logic.md
+++ b/docs/de/plugin-dev/plugin-template/basic-logic.md
@@ -149,7 +149,7 @@ In `on_load` initialisieren wir das Pumpkin‑Logging und geben eine Info‑Nach
 ```rs [lib.rs]
 #[plugin_method]
 async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
-    pumpkin::init_log!(); // [!code ++:3]
+    server.init_log(); // [!code ++:3]
 
     log::info!("Hello, Pumpkin!");
 

--- a/docs/de/plugin-dev/plugin-template/join-event.md
+++ b/docs/de/plugin-dev/plugin-template/join-event.md
@@ -94,7 +94,7 @@ use pumpkin::{
 
 #[plugin_method]
 async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
-    pumpkin::init_log!();
+    server.init_log();
 
     log::info!("Hello, Pumpkin!");
 

--- a/docs/de/plugin-dev/plugin-template/rock-paper-scissors.md
+++ b/docs/de/plugin-dev/plugin-template/rock-paper-scissors.md
@@ -204,7 +204,7 @@ const DESCRIPTION: &str = "Spiele Schere Stein Papier mit dem Server.";
 
 #[plugin_method]
 async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
-    pumpkin::init_log!();
+    server.init_log();
 
     log::info!("Hallo, Pumpkin!");
 

--- a/docs/en/plugin-dev/plugin-template/basic-logic.md
+++ b/docs/en/plugin-dev/plugin-template/basic-logic.md
@@ -123,6 +123,12 @@ This method gets a mutable reference to its plugin object (in this case the `MyP
 ### Methods implemented on the `Context` object
 
 ```rs
+fn init_log()
+```
+
+Enables logging via the `log` crate.
+
+```rs
 fn get_data_folder() -> String
 ```
 
@@ -159,7 +165,7 @@ Add this to the `on_load` method:
 ```rs [lib.rs]
 #[plugin_method]
 async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
-    pumpkin::init_log!(); // [!code ++:3]
+    server.init_log(); // [!code ++:3]
 
     log::info!("Hello, Pumpkin!");
 

--- a/docs/en/plugin-dev/plugin-template/join-event.md
+++ b/docs/en/plugin-dev/plugin-template/join-event.md
@@ -97,7 +97,7 @@ use pumpkin::{
 
 #[plugin_method]
 async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
-    pumpkin::init_log!();
+    server.init_log();
 
     log::info!("Hello, Pumpkin!");
 

--- a/docs/en/plugin-dev/plugin-template/rock-paper-scissors.md
+++ b/docs/en/plugin-dev/plugin-template/rock-paper-scissors.md
@@ -206,7 +206,7 @@ const DESCRIPTION: &str = "Play Rock Paper Scissors with the server.";
 
 #[plugin_method]
 async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
-    pumpkin::init_log!();
+    server.init_log();
 
     log::info!("Hello, Pumpkin!");
 

--- a/docs/nl/plugin-dev/plugin-template/basic-logic.md
+++ b/docs/nl/plugin-dev/plugin-template/basic-logic.md
@@ -136,7 +136,7 @@ Add this to the `on_load` method:
 ```rs [lib.rs]
 #[plugin_method]
 async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
-    pumpkin::init_log!(); // [!code ++:3]
+    server.init_log(); // [!code ++:3]
 
     log::info!("Hello, Pumpkin!");
 

--- a/docs/nl/plugin-dev/plugin-template/join-event.md
+++ b/docs/nl/plugin-dev/plugin-template/join-event.md
@@ -76,7 +76,7 @@ use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler}; // [!code
 
 #[plugin_method]
 async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
-    pumpkin::init_log!();
+    server.init_log();
 
     log::info!("Hello, Pumpkin!");
 

--- a/docs/pt/plugin-dev/plugin-template/basic-logic.md
+++ b/docs/pt/plugin-dev/plugin-template/basic-logic.md
@@ -159,7 +159,7 @@ Adicione isso ao método `on_load`:
 ```rs [lib.rs]
 #[plugin_method]
 async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
-    pumpkin::init_log!(); // [!code ++:3]
+    server.init_log(); // [!code ++:3]
 
     log::info!("Hello, Pumpkin!");
 

--- a/docs/pt/plugin-dev/plugin-template/join-event.md
+++ b/docs/pt/plugin-dev/plugin-template/join-event.md
@@ -86,7 +86,7 @@ use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler}; // [!cód
 
 #[plugin_method]
 async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
-    pumpkin::init_log!();
+    server.init_log();
 
     log::info!("Olá, Pumpkin!");
 

--- a/docs/zh_cn/plugin-dev/plugin-template/basic-logic.md
+++ b/docs/zh_cn/plugin-dev/plugin-template/basic-logic.md
@@ -159,7 +159,7 @@ async fn register_event(handler: Arc<H>, priority: EventPriority, blocking: bool
 ```rs [lib.rs]
 #[plugin_method]
 async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
-    pumpkin::init_log!(); // [!code ++:3]
+    server.init_log(); // [!code ++:3]
 
     log::info!("Hello, Pumpkin !");
 

--- a/docs/zh_cn/plugin-dev/plugin-template/join-event.md
+++ b/docs/zh_cn/plugin-dev/plugin-template/join-event.md
@@ -88,7 +88,7 @@ use pumpkin::plugin::{player::PlayerJoinEvent, Context, EventHandler}; // [!code
 
 #[plugin_method]
 async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
-    pumpkin::init_log!();
+    server.init_log();
 
     log::info!("你好， Pumpkin ！");
 


### PR DESCRIPTION
This is contigent on https://github.com/Pumpkin-MC/Pumpkin/pull/1241 being merged.