### PR TITLE
self-host addr quickstart tip

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -36,13 +36,9 @@ RUSTFLAGS='-C target-cpu=native' cargo run --release
 ```
 
 > [!NOTE]
-> To use (to play on) a server that you are self-hosting on the same local system (e.g. using Prism launcher on Linux to login and run/play minecraft and using Pumpkin to host the server) you may need to use "localhost:25565" as the server address through the 'Multiplayer' -> 'Add Server' -> 'Server Address' pathway, though "localhost:25565" address is not listed in the terminal's run-server output.
+> To use (to play on) a server that you are self-hosting on the same local system (e.g. using Prism launcher on Linux to login and run/play minecraft and using Pumpkin to host the server) you may need to use "localhost:25565" as the server address through the 'Multiplayer' -> 'Add Server' -> 'Server Address' pathway, though that address is not listed in the terminal's run-server output.
 ```text
 localhost:25565
-```
-
-```shell
-cargo run --release
 ```
 
 ## Docker

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -35,6 +35,16 @@ cargo run --release
 RUSTFLAGS='-C target-cpu=native' cargo run --release
 ```
 
+> [!NOTE]
+> To use (to play on) a server that you are self-hosting on the same local system (e.g. using Prism launcher on Linux to login and run/play minecraft and using Pumpkin to host the server) you may need to use "localhost:25565" as the server address through the 'Multiplayer' -> 'Add Server' -> 'Server Address' pathway, though "localhost:25565" address is not listed in the terminal's run-server output.
+```text
+localhost:25565
+```
+
+```shell
+cargo run --release
+```
+
 ## Docker
 
 > [!IMPORTANT]


### PR DESCRIPTION
Adding instructions for using/testing a self-hosted server, e.g. linux, Prism-Launcher + Pumpkin:
'Multiplayer' -> 'Add Server' -> Server Address = "localhost:25565"