### PR TITLE
fix: update download link

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -5,7 +5,7 @@ Pre-release: Currently under development and not yet ready for official release.
 
 ## Download Pre-Release binaries
 
-You can download pre-built binaries on the [Pre-release Download Page](https://pumpkinmc.org/download.html)
+You can download pre-built binaries on the [Pre-release Download Page](https://pumpkinmc.org/download)
 
 ## Build from Source (Rust)
 

--- a/docs/tr_TR/index.md
+++ b/docs/tr_TR/index.md
@@ -5,7 +5,7 @@
 
 ## Ön Sürüm İkili Dosyalarını İndir
 
-Hazır derlenmiş ikili dosyaları [Ön Sürüm İndirme Sayfası](https://pumpkinmc.org/download.html) üzerinden indirebilirsiniz.
+Hazır derlenmiş ikili dosyaları [Ön Sürüm İndirme Sayfası](https://pumpkinmc.org/download) üzerinden indirebilirsiniz.
 
 ## Kaynaktan Derleme (Rust)
 

--- a/docs/zh_cn/index.md
+++ b/docs/zh_cn/index.md
@@ -5,7 +5,7 @@
 
 ## 下载预发布二进制文件
 
-您可以在[预发布下载页面](https://pumpkinmc.org/download.html)下载预构建的二进制文件
+您可以在[预发布下载页面](https://pumpkinmc.org/download)下载预构建的二进制文件
 
 ## 从源码构建（Rust）
 


### PR DESCRIPTION
Change old `https://pumpkinmc.org/download.html` link to new `https://pumpkinmc.org/download` link
