### PR TITLE
Fix broken "World" and "Mobile dev" links in the sidebar

### DIFF
--- a/docs/.vitepress/en.ts
+++ b/docs/.vitepress/en.ts
@@ -58,8 +58,8 @@ export const en = defineConfig({
                             },
                         ],
                     },
-                    { text: "World", link: "developer/world" },
-                    { text: "Mobile dev", link: "developer/mobile" },
+                    { text: "World", link: "/developer/world" },
+                    { text: "Mobile dev", link: "/developer/mobile" },
                 ],
             },
             {


### PR DESCRIPTION
## Expected behaviour:

Correct sidebar item is highlighted

<img width="1500" height="565" alt="image" src="https://github.com/user-attachments/assets/061c8873-86a8-4dee-9677-f761912f88b3" />


## Current behaviour

`World` and `Mobile dev` in english version are not highlighted

<img width="1233" height="491" alt="image" src="https://github.com/user-attachments/assets/d0bfbd3b-e15a-44f9-97b2-9bbafa6ae351" />

## PR change

Links are highlighted properly

<img width="1504" height="583" alt="image" src="https://github.com/user-attachments/assets/eda0b040-246f-4092-abc7-adca6038d845" />
