### PR TITLE
Change from diff to rust code formatting

### DIFF
--- a/docs/en/plugin-dev/plugin-template/command/first-command.md
+++ b/docs/en/plugin-dev/plugin-template/command/first-command.md
@@ -32,21 +32,21 @@ To make the command usable, you must register both the Permission and the Comman
 
 First, register the Permission. In this example, we set `PermissionDefault::Allow` so that everyone can use the command by default
 
-```diff
+```rust
 #[plugin_method]
 async fn on_load(&mut self, context: Arc<Context>) -> Result<(), String> {
     context.init_log();
 
     log::info!("Hello, Pumpkin!");
 
-+    context
-+        .register_permission(Permission::new(
-+            "plugin_docs_plugin:test",
-+            "Important Test Permission",
-+            PermissionDefault::Allow,
-+        ))
-+        .await
-+        .unwrap();
+    context // [!code ++:8]
+        .register_permission(Permission::new(
+            "plugin_docs_plugin:test",
+            "Important Test Permission",
+            PermissionDefault::Allow,
+        ))
+        .await
+        .unwrap();
 
 
     Ok(())
@@ -55,7 +55,7 @@ async fn on_load(&mut self, context: Arc<Context>) -> Result<(), String> {
 
 Next, register the command using the permission string created above:
 
-```diff
+```rust
 #[plugin_method]
 async fn on_load(&mut self, context: Arc<Context>) -> Result<(), String> {
     context.init_log();
@@ -71,9 +71,9 @@ async fn on_load(&mut self, context: Arc<Context>) -> Result<(), String> {
         .await
         .unwrap();
 
-+    context
-+        .register_command(command::init_command_tree(), "plugin_docs_plugin:test")
-+        .await;
+    context // [!code ++:3]
+        .register_command(command::init_command_tree(), "plugin_docs_plugin:test")
+        .await;
 
     Ok(())
 }


### PR DESCRIPTION
## Before
No syntax highlighting - hard to read

<img width="1070" height="1006" alt="image" src="https://github.com/user-attachments/assets/1fd2d825-937e-4e77-b7e8-24da45eaee9b" />

## After
With syntax hightlighting

<img width="1066" height="996" alt="image" src="https://github.com/user-attachments/assets/13df1661-1cf6-44c1-a25c-72bd7f3a5435" />
