### PR TITLE
Add an Outdated Translation banner based on MD Frontmatter

### DIFF
--- a/docs/.vitepress/components/TranslationBanner.vue
+++ b/docs/.vitepress/components/TranslationBanner.vue
@@ -1,0 +1,74 @@
+<script setup>
+import { computed } from 'vue'
+import { useData, useRoute } from 'vitepress'
+import { data as allVersions } from '../data/versions.data.ts'
+
+const { frontmatter, localeIndex } = useData()
+const route = useRoute()
+
+const defaultUrl = computed(() => {
+  if (localeIndex.value === 'root') return null
+  const prefix = localeIndex.value.startsWith('/') ? localeIndex.value : `/${localeIndex.value}/`
+  let url = route.path.replace(prefix, '/')
+  return url.replace(/\.html$/, '').replace(/\/$/, '') || '/'
+})
+
+const englishVersion = computed(() => {
+  if (!defaultUrl.value) return null
+  return allVersions[defaultUrl.value]
+})
+
+const isOutdated = computed(() => {
+  if (!frontmatter.value?.version || !englishVersion.value) return false
+  return String(frontmatter.value.version) !== String(englishVersion.value)
+})
+</script>
+
+<template>
+  <div v-if="isOutdated" class="translation-banner">
+    <strong class="banner-title">⚠️ OUTDATED TRANSLATION ⚠️</strong>
+    <p class="banner-text">
+      This page is has not been brought up-to-date with the English (Primary) documentation, and may thus contain incorrect information.
+    </p>
+    <a :href="defaultUrl" class="banner-link">View the up-to-date English version &rarr;</a>
+  </div>
+</template>
+
+<style scoped>
+.translation-banner {
+  background-color: var(--vp-c-warning-soft);
+  color: var(--vp-c-warning-text);
+  padding: 16px;
+  border-radius: 8px;
+  margin-bottom: 24px;
+  border: 1px solid var(--vp-c-warning-3);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.banner-title {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.5px;
+}
+
+.banner-text {
+  margin: 0;
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.banner-link {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+  align-self: flex-start;
+  margin-top: 4px;
+}
+
+.banner-link:hover {
+  text-decoration: underline;
+}
+</style>

--- a/docs/.vitepress/data/versions.data.ts
+++ b/docs/.vitepress/data/versions.data.ts
@@ -1,0 +1,21 @@
+import { createContentLoader } from 'vitepress'
+
+export default createContentLoader('en/**/*.md', {
+  transform(rawData) {
+    const versions: Record<string, string> = {}
+
+    for (const page of rawData) {
+      let cleanUrl = page.url.replace(/\.html$/, '').replace(/\/$/, '')
+
+      if (cleanUrl.startsWith('/en/')) {
+        cleanUrl = cleanUrl.replace(/^\/en\//, '/')
+      } else if (cleanUrl === '/en') {
+        cleanUrl = '/'
+      }
+
+      versions[cleanUrl] = String(page.frontmatter.version || '0')
+    }
+
+    return versions
+  }
+})

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -5,12 +5,14 @@ import DefaultTheme from 'vitepress/theme'
 import './style.css'
 import FmtNum from '../components/FmtNum.vue'
 import FmtDateTime from '../components/FmtDateTime.vue'
+import TranslationBanner from '../components/TranslationBanner.vue'
 
 export default {
   extends: DefaultTheme,
   Layout: () => {
     return h(DefaultTheme.Layout, null, {
       // https://vitepress.dev/guide/extending-default-theme#layout-slots
+      'doc-before': () => h(TranslationBanner)
     })
   },
   enhanceApp({ app, router, siteData }) {


### PR DESCRIPTION
Adds the following banner to any translated page with an outdated version number in MD Frontmatter.

<img width="1673" height="742" alt="image" src="https://github.com/user-attachments/assets/88bf78ff-da9e-4bda-84ce-8b6edd41a21c" />

Each page is automatically assigned version "0" when no frontmatter is given. To set a version for each page, the following can be appended to the top of the markdown file.

```
---
version: 1.0
---
```

Closes #19 