### PR TITLE
fix: update decompiling instructions for Minecraft code

### DIFF
--- a/docs/en/developer/contributing.md
+++ b/docs/en/developer/contributing.md
@@ -53,7 +53,7 @@ There are several ways you can contribute to Pumpkin:
 ### Decompiling Minecraft's code
 
 When working at Pumpkin, we heavily rely on the official Minecraft client and utilize existing server logic. We often refer to Minecraft's official code.
-The easiest way to decompile Minecraft is by using Fabric Yarn. Make sure you have Gradle installed before running the following commands:
+The easiest way to decompile Minecraft is by using Fabric Yarn:
 
 ```shell
 git clone https://github.com/FabricMC/yarn.git


### PR DESCRIPTION
Remove mention of needing Gradle installation for decompiling Minecraft. The Gradle wrapper is self-contained.