### PR TITLE
Fix a grammar mistake

### DIFF
--- a/docs/de/config/basic.md
+++ b/docs/de/config/basic.md
@@ -163,7 +163,7 @@ encryption = true
 :::code-group
 
 ```toml [configuration.toml] {2}
-motd = "A Blazing fast Pumpkin Server!"
+motd = "A Blazingly fast Pumpkin Server!"
 ```
 
 :::

--- a/docs/en/config/basic.md
+++ b/docs/en/config/basic.md
@@ -163,7 +163,7 @@ Message of the Day; the server's description displayed on the status screen.
 :::code-group
 
 ```toml [configuration.toml] {2}
-motd = "A Blazing fast Pumpkin Server!"
+motd = "A Blazingly fast Pumpkin Server!"
 ```
 
 :::

--- a/docs/nl/config/basic.md
+++ b/docs/nl/config/basic.md
@@ -139,7 +139,7 @@ De beschrijving van de server die wordt weergegeven op het status scherm.
 
 :::code-group
 ```toml [configuration.toml] {2}
-motd = "A Blazing fast Pumpkin Server!"
+motd = "A Blazingly fast Pumpkin Server!"
 ```
 :::
 

--- a/docs/pt/config/basic.md
+++ b/docs/pt/config/basic.md
@@ -163,7 +163,7 @@ Mensagem do Dia; a descrição do servidor exibida na tela de status.
 :::code-group
 
 ```toml [configuration.toml] {2}
-motd = "A Blazing fast Pumpkin Server!"
+motd = "A Blazingly fast Pumpkin Server!"
 ```
 
 :::

--- a/docs/tr_TR/config/basic.md
+++ b/docs/tr_TR/config/basic.md
@@ -151,7 +151,7 @@ Günün Mesajı; durum ekranında gösterilen sunucu açıklamasını düzenler.
 :::code-group
 
 ```toml [configuration.toml] {2}
-motd = "A Blazing fast Pumpkin Server!"
+motd = "A Blazingly fast Pumpkin Server!"
 ```
 
 :::


### PR DESCRIPTION
Pumpkin's default MOTD says "Blazingly" not "Blazing