### PR TITLE
Fix typo in the Rust docs

### DIFF
--- a/docs/en/plugin-dev/rust/basic-logic.md
+++ b/docs/en/plugin-dev/rust/basic-logic.md
@@ -51,7 +51,7 @@ cargo build --release
 ```
 
 You do not need to build in release mode, but it greatly reduces the size of the wasm plugin and
-increases startup times.
+reduces startup times.
 
 If all went well, you should be left with a message like this:
 


### PR DESCRIPTION
Building a plugin in release mode actually reduces Pumpkin startup time, it doesn't increase it.