### PR TITLE
fix(docs): “Build from Source” instructions missing Git submodules

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -14,7 +14,7 @@ To compile Pumpkin, ensure you have [Rust](https://www.rust-lang.org/tools/insta
 1. **Clone the repository** and navigate into the directory:
 
 ```shell
-git clone https://github.com/Pumpkin-MC/Pumpkin.git
+git clone --recurse-submodules https://github.com/Pumpkin-MC/Pumpkin.git
 cd Pumpkin
 ```
 


### PR DESCRIPTION
Relevant GitHub issue: [Pumpkin-MC/Pumpkin:2327](https://github.com/Pumpkin-MC/Pumpkin/issues/2327).