### PR TITLE
Completely refactor configuration docs adding new options introduced

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,9 +7,9 @@
         "or": "^0.2.0",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.13",
-        "vitepress": "^2.0.0-alpha.17",
-        "vue": "^3.6.0-beta.10",
+        "@types/bun": "^1.3.14",
+        "vitepress": "^2.0.0-alpha.18",
+        "vue": "^3.6.0-beta.17",
       },
     },
   },

--- a/docs/en/config/authentication.md
+++ b/docs/en/config/authentication.md
@@ -1,21 +1,54 @@
 # Authentication
 
-Servers authenthicate with Mojang's session servers in order to ensure the client is playing on a legitimate, paid account. Pumpkin allows you to fully configure authentication.
+Servers authenticate with Mojang's session servers in order to ensure the client is playing on a legitimate, paid account. Pumpkin allows you to fully configure authentication.
 
 ## Configuring Authentication
 
 > [!WARNING]
-> Most servers should not change the default authenthication configuration. Doing so may have unintended consequences. **Only change these settings if you know what you are doing!**
+> Most servers should not change the default authentication configuration. Doing so may have unintended consequences. **Only change these settings if you know what you are doing!**
+
+> [!NOTE]
+> Authentication settings are now per-protocol. Java and Bedrock have separate authentication configurations.
+
+### Java
 
 #### `enabled`: Boolean
 
-Whether authenthication is enabled or not.
+Whether authentication is enabled or not.
 
 :::code-group
 
-```toml [features.toml] {2}
-[authentication]
-enabled = false
+```toml [pumpkin.toml] {2}
+[networking.java.authentication]
+enabled = true
+```
+
+:::
+
+#### `connect_timeout`: Integer
+
+The timeout in milliseconds for connecting to the authentication server.
+
+:::code-group
+
+```toml [pumpkin.toml] {3}
+[networking.java.authentication]
+enabled = true
+connect_timeout = 5000
+```
+
+:::
+
+#### `read_timeout`: Integer
+
+The timeout in milliseconds for reading from the authentication server.
+
+:::code-group
+
+```toml [pumpkin.toml] {3}
+[networking.java.authentication]
+enabled = true
+read_timeout = 5000
 ```
 
 :::
@@ -26,51 +59,10 @@ Whether to block proxy connections or not.
 
 :::code-group
 
-```toml [features.toml] {3}
-[authentication]
+```toml [pumpkin.toml] {3}
+[networking.java.authentication]
 enabled = true
 prevent_proxy_connections = true
-```
-
-:::
-
-#### `url`: String (optional)
-
-The URL to authenthicate with. Uses Mojang's session servers to authenthicate if not specified.
-
-##### Placeholders
-
-| Placeholder     | Description        |
-| --------------- | ------------------ |
-| `{username}`    | Player username    |
-| `{server_hash}` | Hash of the server |
-
-:::code-group
-
-```toml [features.toml] {2}
-[authentication]
-url = "[custom auth server here]"
-```
-
-:::
-
-#### `prevent_proxy_connection_auth_url`: String (optional)
-
-The URL to authenthicate with if `prevent_proxy_connections` is enabled. Uses Mojang's session servers to authenthicate if not specified.
-
-##### Placeholders
-
-| Placeholder     | Description              |
-| --------------- | ------------------------ |
-| `{username}`    | Player username          |
-| `{server_hash}` | Hash of the server       |
-| `{ip}`          | IP Address of the player |
-
-:::code-group
-
-```toml [features.toml] {2}
-[authentication]
-prevent_proxy_connection_auth_url = "[custom auth server here]"
 ```
 
 :::
@@ -83,8 +75,8 @@ Allow players flagged by Mojang.
 
 :::code-group
 
-```toml [features.toml] {2}
-[authentication.player_profile]
+```toml [pumpkin.toml] {2}
+[networking.java.authentication.player_profile]
 allow_banned_players = true
 ```
 
@@ -96,8 +88,8 @@ What actions are allowed if `allow_banned_players` is enabled.
 
 :::code-group
 
-```toml [features.toml] {3}
-[authentication.player_profile]
+```toml [pumpkin.toml] {3}
+[networking.java.authentication.player_profile]
 allow_banned_players = true
 allowed_actions = ["FORCED_NAME_CHANGE", "USING_BANNED_SKIN"]
 ```
@@ -112,8 +104,8 @@ Whether to filter/validate player textures (e.g. skins/capes).
 
 :::code-group
 
-```toml [features.toml] {2}
-[authentication.textures]
+```toml [pumpkin.toml] {2}
+[networking.java.authentication.textures]
 enabled = true
 ```
 
@@ -125,8 +117,8 @@ Allowed URL schemes for textures.
 
 :::code-group
 
-```toml [features.toml] {3}
-[authentication.textures]
+```toml [pumpkin.toml] {3}
+[networking.java.authentication.textures]
 enabled = true
 allowed_url_schemes = ["http", "https"]
 ```
@@ -139,8 +131,8 @@ Allowed URL domains for textures.
 
 :::code-group
 
-```toml [features.toml] {3}
-[authentication.textures]
+```toml [pumpkin.toml] {3}
+[networking.java.authentication.textures]
 enabled = true
 allowed_url_domains = [".minecraft.net", ".mojang.com"]
 ```
@@ -155,8 +147,8 @@ Whether to use player skins or not.
 
 :::code-group
 
-```toml [features.toml] {3}
-[authentication.textures.types]
+```toml [pumpkin.toml] {3}
+[networking.java.authentication.textures.types]
 skin = true
 ```
 
@@ -168,8 +160,8 @@ Whether to use player capes or not.
 
 :::code-group
 
-```toml [features.toml] {3}
-[authentication.textures.types]
+```toml [pumpkin.toml] {3}
+[networking.java.authentication.textures.types]
 cape = true
 ```
 
@@ -181,9 +173,52 @@ Whether to use player elytras or not.
 
 :::code-group
 
-```toml [features.toml] {3}
-[authentication.textures.types]
+```toml [pumpkin.toml] {3}
+[networking.java.authentication.textures.types]
 elytra = true
+```
+
+:::
+
+### Bedrock
+
+#### `enabled`: Boolean
+
+Whether Bedrock authentication is enabled or not.
+
+:::code-group
+
+```toml [pumpkin.toml] {2}
+[networking.bedrock.authentication]
+enabled = true
+```
+
+:::
+
+#### `connect_timeout`: Integer
+
+The timeout in milliseconds for connecting to the authentication server.
+
+:::code-group
+
+```toml [pumpkin.toml] {3}
+[networking.bedrock.authentication]
+enabled = true
+connect_timeout = 5000
+```
+
+:::
+
+#### `read_timeout`: Integer
+
+The timeout in milliseconds for reading from the authentication server.
+
+:::code-group
+
+```toml [pumpkin.toml] {3}
+[networking.bedrock.authentication]
+enabled = true
+read_timeout = 5000
 ```
 
 :::
@@ -191,26 +226,34 @@ elytra = true
 ## Default Config
 
 By default, authentication is enabled and uses Mojang's servers. Here is the default config:
+
 :::code-group
 
-```toml [features.toml]
-[authentication]
+```toml [pumpkin.toml]
+[networking.java.authentication]
 enabled = true
+connect_timeout = 5000
+read_timeout = 5000
 prevent_proxy_connections = false
 
-[authentication.player_profile]
+[networking.java.authentication.player_profile]
 allow_banned_players = false
 allowed_actions = ["FORCED_NAME_CHANGE", "USING_BANNED_SKIN"]
 
-[authentication.textures]
+[networking.java.authentication.textures]
 enabled = true
 allowed_url_schemes = ["http", "https"]
 allowed_url_domains = [".minecraft.net", ".mojang.com"]
 
-[authentication.textures.types]
+[networking.java.authentication.textures.types]
 skin = true
 cape = true
 elytra = true
+
+[networking.bedrock.authentication]
+enabled = true
+connect_timeout = 5000
+read_timeout = 5000
 ```
 
 :::

--- a/docs/en/config/basic.md
+++ b/docs/en/config/basic.md
@@ -1,18 +1,6 @@
 # Basic Configuration
 
-Representing `configuration.toml`
-
-## Server Address
-
-The address to bind the server to.
-
-:::code-group
-
-```toml [configuration.toml] {2}
-server_address = "0.0.0.0:25565"
-```
-
-:::
+These are the root-level options in `pumpkin.toml` for quick and important changes.
 
 ## Seed
 
@@ -20,44 +8,8 @@ The seed for world generation.
 
 :::code-group
 
-```toml [configuration.toml] {2}
+```toml [pumpkin.toml] {1}
 seed = ""
-```
-
-:::
-
-## Max players
-
-The maximum number of players allowed on the server.
-
-:::code-group
-
-```toml [configuration.toml] {2}
-max_players = 100000
-```
-
-:::
-
-## View distance
-
-The maximum view distance for players.
-
-:::code-group
-
-```toml [configuration.toml] {2}
-view_distance = 10
-```
-
-:::
-
-## Simulation distance
-
-The maximum simulation distance for players.
-
-:::code-group
-
-```toml [configuration.toml] {2}
-simulation_distance = 10
 ```
 
 :::
@@ -68,7 +20,7 @@ The default game difficulty.
 
 :::code-group
 
-```toml [configuration.toml] {2}
+```toml [pumpkin.toml] {1}
 default_difficulty = "Normal"
 ```
 
@@ -87,7 +39,7 @@ The permission level assigned by the `/op` command.
 
 :::code-group
 
-```toml [configuration.toml] {2}
+```toml [pumpkin.toml] {1}
 op_permission_level = 4
 ```
 
@@ -99,7 +51,7 @@ Whether the Nether dimension is enabled.
 
 :::code-group
 
-```toml [configuration.toml] {2}
+```toml [pumpkin.toml] {1}
 allow_nether = true
 ```
 
@@ -111,7 +63,7 @@ Whether the End dimension is enabled.
 
 :::code-group
 
-```toml [configuration.toml] {2}
+```toml [pumpkin.toml] {1}
 allow_end = true
 ```
 
@@ -123,47 +75,8 @@ Whether the server is in hardcore mode.
 
 :::code-group
 
-```toml [configuration.toml] {2}
+```toml [pumpkin.toml] {1}
 hardcore = false
-```
-
-:::
-
-## Online Mode
-
-Whether online mode is enabled. Requires valid Minecraft accounts.
-
-:::code-group
-
-```toml [configuration.toml] {2}
-online_mode = true
-```
-
-:::
-
-## Encryption
-
-Whether packet encryption is enabled.
-
-> [!IMPORTANT]
-> Required when online mode is enabled.
-
-:::code-group
-
-```toml [configuration.toml] {2}
-encryption = true
-```
-
-:::
-
-## MOTD
-
-Message of the Day; the server's description displayed on the status screen.
-
-:::code-group
-
-```toml [configuration.toml] {2}
-motd = "A Blazingly fast Pumpkin Server!"
 ```
 
 :::
@@ -174,7 +87,7 @@ The server's target tick rate.
 
 :::code-group
 
-```toml [configuration.toml] {2}
+```toml [pumpkin.toml] {1}
 tps = 20.0
 ```
 
@@ -186,7 +99,7 @@ The default game mode for players.
 
 :::code-group
 
-```toml [configuration.toml] {2}
+```toml [pumpkin.toml] {1}
 default_gamemode = "Survival"
 ```
 
@@ -200,13 +113,25 @@ Adventure
 Spectator
 ```
 
+## Force gamemode
+
+Whether to force the default gamemode on players when they join.
+
+:::code-group
+
+```toml [pumpkin.toml] {1}
+force_gamemode = false
+```
+
+:::
+
 ## IP Scrubbing
 
 Whether to scrub players' IP addresses from logs.
 
 :::code-group
 
-```toml [configuration.toml] {2}
+```toml [pumpkin.toml] {1}
 scrub_ips = true
 ```
 
@@ -218,20 +143,56 @@ Whether to use a server favicon or not.
 
 :::code-group
 
-```toml [configuration.toml] {2}
+```toml [pumpkin.toml] {1}
 use_favicon = true
 ```
 
 :::
 
-## Favicon path
+## Default level name
 
-The path to the server's favicon.
+The name of the default world folder.
 
 :::code-group
 
-```toml [configuration.toml] {2}
-favicon_path = "icon.png"
+```toml [pumpkin.toml] {1}
+default_level_name = "world"
+```
+
+:::
+
+## Allow chat reports
+
+Whether to allow chat reports from players.
+
+:::code-group
+
+```toml [pumpkin.toml] {1}
+allow_chat_reports = false
+```
+
+:::
+
+## White list
+
+Whether the white list is enabled.
+
+:::code-group
+
+```toml [pumpkin.toml] {1}
+white_list = false
+```
+
+:::
+
+## Enforce whitelist
+
+Whether to enforce the white list by kicking players not on it.
+
+:::code-group
+
+```toml [pumpkin.toml] {1}
+enforce_whitelist = false
 ```
 
 :::

--- a/docs/en/config/commands.md
+++ b/docs/en/config/commands.md
@@ -10,9 +10,22 @@ Whether commands from the console are accepted or not.
 
 :::code-group
 
-```toml [features.toml] {2}
+```toml [pumpkin.toml] {2}
 [commands]
 use_console = false
+```
+
+:::
+
+#### `use_tty`: Boolean
+
+Whether to use TTY for the console or not.
+
+:::code-group
+
+```toml [pumpkin.toml] {2}
+[commands]
+use_tty = true
 ```
 
 :::
@@ -23,20 +36,34 @@ Whether commands from players should be logged in the console or not.
 
 :::code-group
 
-```toml [features.toml] {2}
+```toml [pumpkin.toml] {2}
 [commands]
 log_console = false
 ```
 
 :::
 
-## Operation permission level
+#### `broadcast_console_to_ops`: Boolean
+
+Whether console output should be broadcast to operators or not.
+
+:::code-group
+
+```toml [pumpkin.toml] {2}
+[commands]
+broadcast_console_to_ops = true
+```
+
+:::
+
+#### `default_op_level`: Integer
 
 The default permission level for all players.
 
 :::code-group
 
-```toml [configuration.toml] {2}
+```toml [pumpkin.toml] {2}
+[commands]
 default_op_level = 0
 ```
 
@@ -48,10 +75,12 @@ By default, Pumpkin will allow commands from console and log all commands run by
 
 :::code-group
 
-```toml [features.toml]
+```toml [pumpkin.toml]
 [commands]
 use_console = true
+use_tty = true
 log_console = true
+broadcast_console_to_ops = true
 default_op_level = 0
 ```
 

--- a/docs/en/config/compression.md
+++ b/docs/en/config/compression.md
@@ -4,17 +4,22 @@ Compression is used to reduce the size of packets. This is beneficial to reduce 
 
 ## Configuring compression
 
+> [!NOTE]
+> Compression settings are now per-protocol. Java and Bedrock have separate compression configurations.
+
+### Java
+
 #### `enabled`: Boolean
 
-Whether packet compression is enabled or not.
+Whether packet compression is enabled for Java clients or not.
 
 > [!TIP]
 > It might be beneficial to disable compression if the server is behind a proxy.
 
 :::code-group
 
-```toml [features.toml] {2}
-[packet_compression]
+```toml [pumpkin.toml] {2}
+[networking.java.compression]
 enabled = true
 ```
 
@@ -29,8 +34,9 @@ The minimum packet size before the server attempts to compress the packet.
 
 :::code-group
 
-```toml [features.toml] {2}
-[packet_compression]
+```toml [pumpkin.toml] {3}
+[networking.java.compression]
+enabled = true
 threshold = 256
 ```
 
@@ -42,21 +48,70 @@ A value between 0 to 9: 0 to disable compression, 1 being the fastest compressio
 
 :::code-group
 
-```toml [features.toml] {2}
-[packet_compression]
+```toml [pumpkin.toml] {3}
+[networking.java.compression]
+enabled = true
 level = 4
 ```
 
 :::
 
-## Default config
+### Bedrock
+
+#### `enabled`: Boolean
+
+Whether packet compression is enabled for Bedrock clients or not.
+
+:::code-group
+
+```toml [pumpkin.toml] {2}
+[networking.bedrock.compression]
+enabled = true
+```
+
+:::
+
+#### `threshold`: Integer (0-1024)
+
+The minimum packet size before the server attempts to compress the packet.
+
+:::code-group
+
+```toml [pumpkin.toml] {3}
+[networking.bedrock.compression]
+enabled = true
+threshold = 256
+```
+
+:::
+
+#### `level`: Integer (0-9)
+
+A value between 0 to 9: 0 to disable compression, 1 being the fastest compression (at the cost of size), and 9 being maximum compression (at the cost of speed).
+
+:::code-group
+
+```toml [pumpkin.toml] {3}
+[networking.bedrock.compression]
+enabled = true
+level = 4
+```
+
+:::
+
+## Default Config
 
 By default, compression is enabled.
 
 :::code-group
 
-```toml [features.toml]
-[packet_compression]
+```toml [pumpkin.toml]
+[networking.java.compression]
+enabled = true
+threshold = 256
+level = 4
+
+[networking.bedrock.compression]
 enabled = true
 threshold = 256
 level = 4

--- a/docs/en/config/introduction.md
+++ b/docs/en/config/introduction.md
@@ -2,14 +2,14 @@
 
 Pumpkin offers a robust configuration system that allows users to customize various aspects of the server's behavior without relying on external plugins. This provides flexibility and control over the server's operation.
 
-### Basic / Advanced
+### Configuration File
 
-Pumpkin's configuration is split into a "basic" configuration made for quick changes and important changes, and a more "advanced" configuration
+Pumpkin uses a single `pumpkin.toml` file located in the server's root directory.
 
-- `config/configuration.toml`: simple and can be compared to the vanilla `server.properties`.
-- `config/features.toml`: designed to have all features of pumpkin at one place, making it a large configuration
+> [!NOTE]
+> Since [this commit](https://github.com/Pumpkin-MC/Pumpkin/commit/c8633b78d76b464323269ca04bd3b79dfc08cf13), the old separate `configuration.toml` and `features.toml` files have been merged into a single `pumpkin.toml`.
 
-You can create those two files under `config/` folder before running Pumpkin, or edit them after the initial run of Pumpkin.
+You can create this file before running Pumpkin, or edit it after the initial run.
 
 ### Server Version
 

--- a/docs/en/config/lan-broadcast.md
+++ b/docs/en/config/lan-broadcast.md
@@ -1,6 +1,6 @@
 # LAN Broadcast
 
-Pumpkin can advertise the server across the network in order to make it easier for local players to connect to the server easier.
+Pumpkin can advertise the server across the network in order to make it easier for local players to connect to the server.
 
 ## Configuring LAN Broadcast
 
@@ -10,43 +10,9 @@ Whether LAN broadcast is enabled or not.
 
 :::code-group
 
-```toml [features.toml] {2}
-[lan_broadcast]
+```toml [pumpkin.toml] {2}
+[networking.lan_broadcast]
 enabled = true
-```
-
-:::
-
-#### `motd`: String (optional)
-
-The MOTD to broadcast out to clients; uses the server's MOTD by default.
-
-> [!CAUTION]
-> LAN broadcast MOTD does not support multiple lines, RGB colors, or gradients. Pumpkin does not verify the MOTD before broadcasting it. If the server MOTD is using these components, consider defining this field so that clients see a proper MOTD.
-
-:::code-group
-
-```toml [features.toml] {3}
-[lan_broadcast]
-enabled = true
-motd = "[your MOTD here]"
-```
-
-:::
-
-#### `port`: Integer (0-65535) (optional)
-
-What port to bind to. If not specified, will bind to port 0 (any available port on the system).
-
-> [!IMPORTANT]
-> The protocol defines what port to broadcast to. This option only exists to specify which port to bind to on the host. This option purely exists so that the port can be predictable.
-
-:::code-group
-
-```toml [features.toml] {3}
-[lan_broadcast]
-enabled = true
-port = 46733
 ```
 
 :::
@@ -57,11 +23,9 @@ By default, LAN broadcast is disabled.
 
 :::code-group
 
-```toml [features.toml]
-[lan_broadcast]
+```toml [pumpkin.toml]
+[networking.lan_broadcast]
 enabled = false
-motd = "[server MOTD here]"
-port = 0
 ```
 
 :::

--- a/docs/en/config/logging.md
+++ b/docs/en/config/logging.md
@@ -10,7 +10,7 @@ Whether logging is enabled or not.
 
 :::code-group
 
-```toml [features.toml] {2}
+```toml [pumpkin.toml] {2}
 [logging]
 enabled = true
 ```
@@ -30,7 +30,7 @@ The log verbosity level. Possible values are:
 
 :::code-group
 
-```toml [features.toml] {3}
+```toml [pumpkin.toml] {3}
 [logging]
 enabled = true
 level = "Debug"
@@ -44,7 +44,7 @@ Whether to allow choosing the log level by setting the `RUST_LOG` environment va
 
 :::code-group
 
-```toml [features.toml] {3}
+```toml [pumpkin.toml] {3}
 [logging]
 enabled = true
 env = true
@@ -58,7 +58,7 @@ Whether to print threads in the logging message or not.
 
 :::code-group
 
-```toml [features.toml] {3}
+```toml [pumpkin.toml] {3}
 [logging]
 enabled = true
 threads = false
@@ -72,7 +72,7 @@ Whether to print to the console with color or not.
 
 :::code-group
 
-```toml [features.toml] {3}
+```toml [pumpkin.toml] {3}
 [logging]
 enabled = true
 color = false
@@ -86,10 +86,24 @@ Whether to print the timestamp in the message or not.
 
 :::code-group
 
-```toml [features.toml] {3}
+```toml [pumpkin.toml] {3}
 [logging]
 enabled = true
 timestamp = false
+```
+
+:::
+
+#### `file`: String
+
+The log file name.
+
+:::code-group
+
+```toml [pumpkin.toml] {3}
+[logging]
+enabled = true
+file = "latest.log"
 ```
 
 :::
@@ -100,14 +114,13 @@ By default, logging is enabled at the `Info` level and will print with color, th
 
 :::code-group
 
-```toml [features.toml]
+```toml [pumpkin.toml]
 [logging]
 enabled = true
-level = "Info"
-env = false
 threads = true
 color = true
 timestamp = true
+file = "latest.log"
 ```
 
 :::

--- a/docs/en/config/proxy.md
+++ b/docs/en/config/proxy.md
@@ -16,8 +16,8 @@ Enables support for proxies.
 
 :::code-group
 
-```toml [features.toml]{2}
-[proxy]
+```toml [pumpkin.toml] {2}
+[networking.proxy]
 enabled = true
 ```
 
@@ -31,8 +31,8 @@ Whether Velocity support is enabled or not.
 
 :::code-group
 
-```toml [features.toml]{2}
-[proxy.velocity]
+```toml [pumpkin.toml] {2}
+[networking.proxy.velocity]
 enabled = true
 ```
 
@@ -44,8 +44,8 @@ The secret as configured in Velocity.
 
 :::code-group
 
-```toml [features.toml]{3}
-[proxy.velocity]
+```toml [pumpkin.toml] {3}
+[networking.proxy.velocity]
 enabled = true
 secret = "[proxy secret here]"
 ```
@@ -60,8 +60,8 @@ Whether BungeeCord support is enabled or not.
 
 :::code-group
 
-```toml [features.toml]{2}
-[proxy.bungeecord]
+```toml [pumpkin.toml] {2}
+[networking.proxy.bungeecord]
 enabled = true
 ```
 
@@ -76,15 +76,15 @@ By default, proxy support is disabled. Here is the default config:
 
 :::code-group
 
-```toml [features.toml]
-[proxy]
+```toml [pumpkin.toml]
+[networking.proxy]
 enabled = false
 
-[proxy.velocity]
+[networking.proxy.velocity]
 enabled = false
 secret = ""
 
-[proxy.bungeecord]
+[networking.proxy.bungeecord]
 enabled = false
 ```
 

--- a/docs/en/config/pvp.md
+++ b/docs/en/config/pvp.md
@@ -10,7 +10,7 @@ Whether PVP is enabled or not.
 
 :::code-group
 
-```toml [features.toml] {2}
+```toml [pumpkin.toml] {2}
 [pvp]
 enabled = true
 ```
@@ -23,7 +23,7 @@ Whether to show red hurt animation and FOV bobbing or not.
 
 :::code-group
 
-```toml [features.toml] {2}
+```toml [pumpkin.toml] {2}
 [pvp]
 hurt_animation = true
 ```
@@ -36,7 +36,7 @@ Whether to protect players in creative against PVP or not.
 
 :::code-group
 
-```toml [features.toml] {2}
+```toml [pumpkin.toml] {2}
 [pvp]
 protect_creative = true
 ```
@@ -49,7 +49,7 @@ Whether attacks should have knockback or not.
 
 :::code-group
 
-```toml [features.toml] {2}
+```toml [pumpkin.toml] {2}
 [pvp]
 knockback = true
 ```
@@ -62,7 +62,7 @@ Whether players should swing when attacking or not.
 
 :::code-group
 
-```toml [features.toml] {2}
+```toml [pumpkin.toml] {2}
 [pvp]
 swing = true
 ```
@@ -75,7 +75,7 @@ By default, all PVP options are enabled in order to match vanilla behavior.
 
 :::code-group
 
-```toml [features.toml]
+```toml [pumpkin.toml]
 [pvp]
 enabled = true
 hurt_animation = true

--- a/docs/en/config/query.md
+++ b/docs/en/config/query.md
@@ -10,23 +10,23 @@ Whether to listen for Query protocol requests or not.
 
 :::code-group
 
-```toml [features.toml] {2}
-[query]
+```toml [pumpkin.toml] {2}
+[networking.query]
 enabled = true
 ```
 
 :::
 
-#### `port`: Integer (0-65535) (optional)
+#### `address`: String
 
-Which port to listen to Query protocol requests on. If not specified, it uses the same port as the server.
+The address and port to listen for Query protocol requests on.
 
 :::code-group
 
-```toml [features.toml] {3}
-[query]
+```toml [pumpkin.toml] {3}
+[networking.query]
 enabled = true
-address = "0.0.0.0:12345"
+address = "0.0.0.0:25565"
 ```
 
 :::
@@ -37,8 +37,8 @@ By default, Query is disabled. It will run on the server port if enabled unless 
 
 :::code-group
 
-```toml [features.toml]
-[query]
+```toml [pumpkin.toml]
+[networking.query]
 enabled = true
 address = "0.0.0.0:25565"
 ```

--- a/docs/en/config/rcon.md
+++ b/docs/en/config/rcon.md
@@ -6,10 +6,12 @@ RCON is a protocol that allows you to remotely manage the server from a differen
 
 #### `enabled`: Boolean
 
+Whether RCON is enabled or not.
+
 :::code-group
 
-```toml [features.toml] {2}
-[rcon]
+```toml [pumpkin.toml] {2}
+[networking.rcon]
 enabled = true
 ```
 
@@ -21,8 +23,8 @@ The address and port that RCON should listen to.
 
 :::code-group
 
-```toml [features.toml] {3}
-[rcon]
+```toml [pumpkin.toml] {3}
+[networking.rcon]
 enabled = true
 address = "0.0.0.0:25575"
 ```
@@ -35,8 +37,8 @@ The password to use for RCON authentication.
 
 :::code-group
 
-```toml [features.toml] {3}
-[rcon]
+```toml [pumpkin.toml] {3}
+[networking.rcon]
 enabled = true
 password = "[your safe password here]"
 ```
@@ -49,8 +51,8 @@ The max number of RCON connections allowed at a single time. Set this to 0 to di
 
 :::code-group
 
-```toml [features.toml] {3}
-[rcon]
+```toml [pumpkin.toml] {3}
+[networking.rcon]
 enabled = true
 max_connections = 5
 ```
@@ -59,54 +61,54 @@ max_connections = 5
 
 ### Logging
 
-#### `log_logged_successfully`: Boolean
+#### `logged_successfully`: Boolean
 
 Whether successful logins should be logged to console or not.
 
 :::code-group
 
-```toml [features.toml] {2}
-[rcon.logging]
-log_logged_successfully = true
+```toml [pumpkin.toml] {2}
+[networking.rcon.logging]
+logged_successfully = true
 ```
 
 :::
 
-#### `log_wrong_password`: Boolean
+#### `wrong_password`: Boolean
 
 Whether wrong password attempts should be logged to console or not.
 
 :::code-group
 
-```toml [features.toml] {2}
-[rcon.logging]
-log_logged_successfully = true
+```toml [pumpkin.toml] {2}
+[networking.rcon.logging]
+wrong_password = true
 ```
 
 :::
 
-#### `log_commands`: Boolean
+#### `commands`: Boolean
 
 Whether to log commands ran from RCON to console or not.
 
 :::code-group
 
-```toml [features.toml] {2}
-[rcon.logging]
-log_commands = true
+```toml [pumpkin.toml] {2}
+[networking.rcon.logging]
+commands = true
 ```
 
 :::
 
-#### `log_quit`: Boolean
+#### `quit`: Boolean
 
 Whether RCON client quit should be logged or not.
 
 :::code-group
 
-```toml [features.toml] {2}
-[rcon.logging]
-log_quit = true
+```toml [pumpkin.toml] {2}
+[networking.rcon.logging]
+quit = true
 ```
 
 :::
@@ -117,18 +119,18 @@ By default, RCON is disabled.
 
 :::code-group
 
-```toml [features.toml]
-[rcon]
+```toml [pumpkin.toml]
+[networking.rcon]
 enabled = false
 address = "0.0.0.0:25575"
 password = ""
-max_connections = 0
+max_connections = 10
 
-[rcon.logging]
-log_logged_successfully = true
-log_wrong_password = true
-log_commands = true
-log_quit = true
+[networking.rcon.logging]
+logged_successfully = true
+wrong_password = true
+commands = true
+quit = true
 ```
 
 :::

--- a/docs/en/config/resource-pack.md
+++ b/docs/en/config/resource-pack.md
@@ -7,20 +7,25 @@ Servers can send resource packs to clients in order to change the appearance of 
 
 ## Configuring Resource Pack
 
+> [!NOTE]
+> Resource pack settings are now per-protocol. Java and Bedrock have separate resource pack configurations.
+
+### Java
+
 #### `enabled`: Boolean
 
 Whether a resource pack is enabled or not.
 
 :::code-group
 
-```toml [features.toml] {2}
-[resource_pack]
+```toml [pumpkin.toml] {2}
+[resource_pack.java]
 enabled = true
 ```
 
 :::
 
-#### `resource_pack_url`: String
+#### `url`: String
 
 The direct download URL to the resource pack.
 
@@ -29,15 +34,15 @@ The direct download URL to the resource pack.
 
 :::code-group
 
-```toml [features.toml] {3}
-[resource_pack]
+```toml [pumpkin.toml] {3}
+[resource_pack.java]
 enabled = true
-resource_pack_url = "[your download URL here]"
+url = "[your download URL here]"
 ```
 
 :::
 
-#### `resource_pack_sha1`: String
+#### `sha1`: String
 
 The SHA1 hash of the resource pack.
 
@@ -66,10 +71,10 @@ sha1sum [file]
 
 :::code-group
 
-```toml [features.toml] {3}
-[resource_pack]
+```toml [pumpkin.toml] {3}
+[resource_pack.java]
 enabled = true
-resource_pack_sha1 = "[your hash here]"
+sha1 = "[your hash here]"
 ```
 
 :::
@@ -80,8 +85,8 @@ The message to show to the user when prompted to download the resource pack.
 
 :::code-group
 
-```toml [features.toml] {3}
-[resource_pack]
+```toml [pumpkin.toml] {3}
+[resource_pack.java]
 enabled = true
 prompt_message = "[your message here]"
 ```
@@ -94,10 +99,53 @@ Whether to force the client to download the resource pack or not. If the client 
 
 :::code-group
 
-```toml [features.toml] {3}
-[resource_pack]
+```toml [pumpkin.toml] {3}
+[resource_pack.java]
 enabled = true
 force = false
+```
+
+:::
+
+### Bedrock
+
+#### `enabled`: Boolean
+
+Whether a resource pack is enabled for Bedrock clients or not.
+
+:::code-group
+
+```toml [pumpkin.toml] {2}
+[resource_pack.bedrock]
+enabled = false
+```
+
+:::
+
+#### `force`: Boolean
+
+Whether to force the client to download the resource pack or not.
+
+:::code-group
+
+```toml [pumpkin.toml] {3}
+[resource_pack.bedrock]
+enabled = false
+force = false
+```
+
+:::
+
+#### `packs`: String Array
+
+A list of resource pack URLs for Bedrock clients.
+
+:::code-group
+
+```toml [pumpkin.toml] {3}
+[resource_pack.bedrock]
+enabled = false
+packs = []
 ```
 
 :::
@@ -108,13 +156,18 @@ By default, no resource pack is sent to clients.
 
 :::code-group
 
-```toml [features.toml]
-[resource_pack]
+```toml [pumpkin.toml]
+[resource_pack.java]
 enabled = false
-resource_pack_url = ""
-resource_pack_sha1 = ""
+url = ""
+sha1 = ""
 prompt_message = ""
 force = false
+
+[resource_pack.bedrock]
+enabled = false
+force = false
+packs = []
 ```
 
 :::


### PR DESCRIPTION
There is now only 1 config file, `pumpkin.toml`, after [this commit](https://github.com/Pumpkin-MC/Pumpkin/commit/c8633b78d76b464323269ca04bd3b79dfc08cf13). Updated docs/introduction and other pages to reflect that.

Added (and moved) several new configuration options introduced after the last docs update