### PR TITLE
docs: add Nix/NixOS installation instructions (en, de)

### DIFF
--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -59,6 +59,36 @@ docker run --rm \
     -it ghcr.io/pumpkin-mc/pumpkin:master
 ```
 
+## Nix / NixOS
+
+Pumpkin ist als `pumpkin-mc` in [nixpkgs](https://github.com/NixOS/nixpkgs) (gepflegt von [@DerGrumpf](https://github.com/DerGrumpf)), inklusive NixOS‐Modul für den Betrieb als systemd‐Dienst verfügbar.
+
+Ohne Installation testen:
+
+```shell
+nix run nixpkgs#pumpkin-mc
+```
+
+Als Dienst über `configuration.nix`:
+
+```nix
+services.pumpkin-mc = {
+  enable = true;
+  openFirewall = true;
+};
+```
+
+Der Dienst läuft mit `DynamicUser`, `ProtectSystem = "strict"` und ohne zusätzliche Capabilities unter `/var/lib/pumpkin-mc`. Das Modul deckt den Großteil von `pumpkin.toml` über typisierte Optionen deklarativ ab. Netzwerk (Java/Bedrock/RCON/Query/Proxy), Whitelist, Weltformat, Logging, PvP. Was fehlt, lässt sich über die freeform‐Option `settings` einbinden.
+
+> [!NOTE]
+> RCON‐Passwort und Velocity‐Secret werden beim Start aus einer Datei gelesen (`rcon.passwordFile` / `proxy.velocity.secretFile`) und damit nicht im Nix‐Store gespeichert, daher ist der service kompatibel mit `sops-nix`/`agenix`.
+
+Vollständige Optionsliste: [Modul‐Quellcode](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/games/pumpkin-mc.nix), oder:
+
+```shell
+nixos-option services.pumpkin-mc
+```
+
 ## Testserver
 
 Pumpkin hat einen Testserver, der von @kralverde betrieben wird. Er läuft immer auf dem neuesten Commit des Master‑Branches von Pumpkin.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -69,6 +69,38 @@ docker run --rm \
     -it ghcr.io/pumpkin-mc/pumpkin:master
 ```
 
+## Nix / NixOS
+
+Pumpkin is available in [nixpkgs](https://github.com/NixOS/nixpkgs) (maintained by [@DerGrumpf](https://github.com/DerGrumpf)) as the `pumpkin-mc` package, along with a `services.pumpkin-mc` NixOS module for running it as a systemd service.
+
+### Try it without installing
+
+```shell
+nix run nixpkgs#pumpkin-mc
+```
+
+### NixOS module
+
+Add the following to your `configuration.nix`:
+
+```nix
+services.pumpkin-mc = {
+  enable = true;
+  openFirewall = true;
+};
+```
+
+This runs Pumpkin as a hardened systemd service (`DynamicUser`, `ProtectSystem = "strict"`, no extra capabilities) under `/var/lib/pumpkin-mc`. The module exposes typed options for most of `pumpkin.toml`. Java/Bedrock/RCON/query/proxy networking, whitelist, world storage, logging, PvP, and more, plus a `settings` freeform option for anything not yet covered.
+
+> [!NOTE]
+> RCON passwords and Velocity forwarding secrets are read from files at service start (via `rcon.passwordFile` / `proxy.velocity.secretFile`) rather than stored in the Nix store, so they work with secret managers like `sops-nix` or `agenix`.
+
+See the [module source](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/games/pumpkin-mc.nix) for the full list of options, or run:
+
+```shell
+nixos-option services.pumpkin-mc
+```
+
 ## Test Server
 
 Pumpkin has a test server maintained by @kralverde. Its runs on the latest commit of Pumpkin's master branch.


### PR DESCRIPTION
## What
Adds a "Nix / NixOS" section to the Quick Start page, documenting the \`pumpkin-mc\` package and \`services.pumpkin-mc\` NixOS module now available in nixpkgs. Added in English (\`docs/en/index.md\`) and German (\`docs/de/index.md\`), placed after Docker and before the test server section to match the existing installation-method ordering.

## Why
Pumpkin is packaged in nixpkgs (see NixOS/nixpkgs#545183), including a full NixOS module for running it as a systemd service with typed options covering networking, whitelist, world storage, RCON/Velocity secrets (via sops-nix/agenix-compatible file paths), and more. This wasn't documented anywhere.

## Impact
Documentation-only change; no build/site config touched.

## Related
- [NixOS/nixpkgs#545183](https://github.com/NixOS/nixpkgs/pull/545183) (package + module)
- [Pumpkin-MC/Pumpkin#2500](https://github.com/Pumpkin-MC/Pumpkin/pull/2500) (README mention in the main repo)