### PR TITLE
docs(config): document reading the Velocity secret from a file 🤖🤖🤖

### DIFF
--- a/docs/en/config/proxy.md
+++ b/docs/en/config/proxy.md
@@ -24,5 +24,35 @@ enabled = false
 
 - **`[networking.proxy].enabled`**: Master switch to enable proxy support.
 - **`[networking.proxy.velocity].enabled`**: Enables Velocity forwarding protocol.
-- **`[networking.proxy.velocity].secret`**: Forwarding secret matching Velocity proxy configuration.
+- **`[networking.proxy.velocity].secret`**: Forwarding secret matching Velocity proxy configuration. Prefix the value with `@` to read it from a file instead, see [Keeping the secret out of the config](#keeping-the-secret-out-of-the-config).
 - **`[networking.proxy.bungeecord].enabled`**: Enables BungeeCord forwarding protocol.
+
+### Keeping the secret out of the config
+
+`pumpkin.toml` is commonly committed to version control, baked into an image, or pasted into a support thread, which makes it a poor place to keep the forwarding secret. A `secret` value beginning with `@` is read from the file at that path instead of being used literally:
+
+:::code-group
+
+```toml [pumpkin.toml]
+[networking.proxy.velocity]
+enabled = true
+secret = "@forwarding.secret"
+```
+
+:::
+
+Pumpkin then reads the secret from `forwarding.secret`, resolved relative to the server's working directory, the same place `pumpkin.toml` is read from. Absolute paths work too, which lets you point straight at a Docker or Kubernetes secret:
+
+```toml
+secret = "@/run/secrets/velocity_forwarding_secret"
+```
+
+Surrounding whitespace is trimmed, so a trailing newline in the file is harmless. If the referenced file is missing or empty, the server stops during startup with an error rather than starting up and rejecting every player.
+
+On Windows, use a literal string (single quotes) for absolute paths. TOML treats backslashes in a normal double-quoted string as escape characters, so `"@C:\secrets\velocity.txt"` fails to parse:
+
+```toml
+secret = '@C:\secrets\velocity.txt'
+```
+
+If your secret genuinely begins with `@`, double it to escape: `secret = "@@literal"` resolves to the literal value `@literal`.


### PR DESCRIPTION
Documents the `@file` syntax for `networking.proxy.velocity.secret`, added in Pumpkin-MC/Pumpkin#2554.

## What changed

A new "Keeping the secret out of the config" section in `docs/en/config/proxy.md`, plus a pointer to it from the `secret` option itself. It covers:

- `secret = "@forwarding.secret"` reading the value from a file
- Relative paths resolving against the server's working directory, and absolute paths pointing at Docker or Kubernetes secret mounts
- Whitespace trimming, so a trailing newline in the file is harmless
- Startup failure when the referenced file is missing or empty
- The literal-string form Windows users need, since `"@C:\secrets\file"` is an invalid TOML escape
- `@@` escaping a secret that genuinely begins with `@`

## Why

Without this the feature is undiscoverable, and the two sharp edges (TOML backslash escaping on Windows, and how to express a literal leading `@`) are the kind of thing people would otherwise hit and file an issue about.

## Notes

- English only. The same page exists under `de`, `nl`, `pt`, `tr_TR`, and `zh_cn`, but I would rather leave those to native speakers than machine-translate them.
- Should merge alongside or after Pumpkin-MC/Pumpkin#2554, since it documents behaviour that does not exist until that lands.