### PR TITLE
Add dependencies/permissions fields to rust docs

### DIFF
--- a/docs/en/plugin-dev/rust/basic-logic.md
+++ b/docs/en/plugin-dev/rust/basic-logic.md
@@ -23,6 +23,8 @@ impl Plugin for HelloPlugin {
             version: env!("CARGO_PKG_VERSION").into(),
             authors: vec!["Bjorn".into()],
             description: "A simple example plugin".into(),
+            dependencies: vec![],
+            permissions: vec![],
         }
     }
 


### PR DESCRIPTION
When writing a plugin, the PluginMetadata field requires dependencies and permissions fields, which isn't reflected in the docs. I would've changed the code snippet in other languages too, but they don't seem to be directly matching translations.